### PR TITLE
Add tags to conversation summary and add colour tags

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -6,6 +6,8 @@ void init() {
   ConversationPanelView conversation = new ConversationPanelView();
   conversation.personId = 'KGD6192830172';
   conversation.personInfo = '23 years old unmarried female, East';
+  conversation.addTags(new LabelView('label1', '00001'));
+  conversation.addTags(new LabelView('needs_action', '00002', TagColour.Red));
   print(querySelector('main'));
   querySelector('.message-panel').remove();
   querySelector('main').insertBefore(conversation.conversationPanel, querySelector('.reply-panel'));

--- a/lib/view.dart
+++ b/lib/view.dart
@@ -13,23 +13,30 @@ class ConversationPanelView {
   DivElement _messages;
   DivElement _personId;
   DivElement _info;
+  DivElement _tags;
 
   ConversationPanelView() {
     conversationPanel = new DivElement();
     conversationPanel.classes.add('message-panel');
 
-    var conversationSummary = new DivElement();
-    conversationSummary.classes.add('message-summary');
-    _personId = new DivElement();
-    _personId.classes.add('message-summary__id');
-    conversationSummary.append(_personId);
-    _info = new DivElement();
-    _info.classes.add('message-summary__demographics');
-    conversationSummary.append(_info);
+    var conversationSummary = new DivElement()
+      ..classes.add('message-summary');
     conversationPanel.append(conversationSummary);
 
-    _messages = new DivElement();
-    _messages.classes.add('messages');
+    _personId = new DivElement()
+      ..classes.add('message-summary__id');
+    conversationSummary.append(_personId);
+
+    _info = new DivElement()
+      ..classes.add('message-summary__demographics');
+    conversationSummary.append(_info);
+
+    _tags = new DivElement()
+      ..classes.add('message-summary__tags');
+    conversationSummary.append(_tags);
+
+    _messages = new DivElement()
+      ..classes.add('messages');
     conversationPanel.append(_messages);
   }
 
@@ -38,6 +45,10 @@ class ConversationPanelView {
 
   addMessage(MessageView message) {
     _messages.append(message.message);
+  }
+
+  addTags(LabelView label) {
+    _tags.append(label.label);
   }
 }
 
@@ -94,13 +105,32 @@ class MessageView {
   }
 }
 
+enum TagColour {
+  None,
+  Green,
+  Yellow,
+  Red
+}
+
 class LabelView {
   DivElement label;
 
-  LabelView(String text, String labelId) {
+  LabelView(String text, String labelId, [TagColour tagColour = TagColour.None]) {
     label = new DivElement()
       ..classes.add('label')
       ..dataset['id'] = labelId;
+    switch (tagColour) {
+      case TagColour.Green:
+        label.classes.add('label--green');
+        break;
+      case TagColour.Yellow:
+        label.classes.add('label--yellow');
+        break;
+      case TagColour.Red:
+        label.classes.add('label--red');
+        break;
+      default:
+    }
 
     var labelText = new SpanElement()
       ..classes.add('label__name')

--- a/web/index.html
+++ b/web/index.html
@@ -45,6 +45,16 @@
             <div class="message-summary">
                 <div class="message-summary__id">KGD6192830172</div>
                 <div class="message-summary__demographics">23 years old unmarried female, East</div>
+                <div class="message-summary__tags">
+                    <div class="label" data-id="0000-1">
+                        <span class="label__name">label1</span>
+                        <span class="label__remove"></span>
+                    </div>
+                    <div class="label label--red" data-id="0000-2">
+                        <span class="label__name">needs_action</span>
+                        <span class="label__remove"></span>
+                    </div>
+                </div>
             </div>
             <div class="messages">
                 <div class="message message--incoming" data-id="0000">

--- a/web/labels.css
+++ b/web/labels.css
@@ -4,6 +4,16 @@
   display: flex;
 }
 
+.label.label--green {
+  color:  darkgreen;
+}
+.label.label--yellow {
+  color: darkorange;
+}
+.label.label--red {
+  color: crimson;
+}
+
 .label__name {
   padding: 2px 5px;
   margin: 1px 0;
@@ -14,7 +24,7 @@
 .label__remove {
   width: 16px;
   height: 16px;
-  margin: 1px 0 1px 2px;
+  margin: 1px 2px 1px 2px;
   padding: 3px 0;
   border-radius: 2px;
   display: inline-block;

--- a/web/styles.css
+++ b/web/styles.css
@@ -85,3 +85,8 @@ main {
 .message-summary__demographics {
     color: #666;
 }
+
+.message-summary__tags {
+    display: flex;
+    place-content: center;
+}


### PR DESCRIPTION
Please have a look at the screenshot below. I'm not entirely sure that showing the X button for the tags on hover works when the tags are in the conversation summary area. Either way, I can play later on with how it looks.

Thanks @lukechurch !

<img width="1919" alt="Screenshot 2019-05-11 at 23 12 33" src="https://user-images.githubusercontent.com/1173973/57575469-6c96da80-7442-11e9-827c-a989026352d8.png">
