### PR TITLE
Add keypress listener

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -33,6 +33,7 @@ enum UIAction {
   userSignedOut,
   signInButtonClicked,
   signOutButtonClicked,
+  keyPressed,
 }
 
 class Data {}
@@ -87,6 +88,11 @@ class UserData extends Data {
   String email;
   String photoUrl;
   UserData(this.displayName, this.email, this.photoUrl);
+}
+
+class KeyPressData extends Data {
+  String key;
+  KeyPressData(this.key);
 }
 
 UIActionContext actionContextState;
@@ -268,6 +274,8 @@ void command(UIAction action, Data data) {
       break;
     case UIAction.signOutButtonClicked:
       platform.signOut();
+      break;
+    case UIAction.keyPressed:
       break;
     default:
   }

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -28,6 +28,8 @@ void init() {
 
   querySelector('header')
     ..append(authView.authElement);
+
+  document.onKeyPress.listen((event) => command(UIAction.keyPressed, new KeyPressData(event.key)));
 }
 
 const REPLY_PANEL_TITLE = 'Suggested responses';
@@ -150,7 +152,8 @@ class MessageView {
       ..classes.add('message__translation')
       ..contentEditable = 'true'
       ..text = translation
-      ..onInput.listen((_) => command(UIAction.updateTranslation, new TranslationData(_messageTranslation.text, conversationId, messageIndex)));
+      ..onInput.listen((_) => command(UIAction.updateTranslation, new TranslationData(_messageTranslation.text, conversationId, messageIndex)))
+      ..onKeyPress.listen((e) => e.stopPropagation());
     _messageBubble.append(_messageTranslation);
 
     _messageTags = new DivElement()
@@ -328,8 +331,9 @@ class ReplyPanelView {
 
     _notesTextarea = new DivElement()
       ..classes.add('notes-box__textarea')
-      ..contentEditable = 'true';
-    _notesTextarea.onInput.listen((_) => command(UIAction.updateNote, new NoteData(_notesTextarea.text)));
+      ..contentEditable = 'true'
+      ..onInput.listen((_) => command(UIAction.updateNote, new NoteData(_notesTextarea.text)))
+      ..onKeyPress.listen((e) => e.stopPropagation());
     _notes.append(_notesTextarea);
   }
 


### PR DESCRIPTION
This just adds a listener for keypresses on the DOM, except for the places where the user can write text (ie. when translating and writing notes).

I'll be following this up with more implementation in the controller to support the reply -> tag -> next conversation, but they involve other changes which are not related to keystrokes, so I'm separating this in two PRs.

Thanks!