### PR TITLE
Remove call to populate reply panel before receiving replies

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -143,9 +143,6 @@ void populateUI() async {
   }
   actionObjectState = UIActionObject.conversation;
 
-  // Fill in replyPanelView
-  _populateReplyPanelView(suggestedReplies);
-
   platform.listenForConversationTags(
     (tags) {
       var updatedIds = tags.map((t) => t.tagId).toSet();


### PR DESCRIPTION
I think this was left over from when we were using the mock suggested replies before we switched to loading them from Firebase.

Thanks!