### PR TITLE
Scroll selected conversation and last message into view

### DIFF
--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -103,6 +103,7 @@ class ConversationPanelView {
   void addMessage(MessageView message) {
     _messages.append(message.message);
     _messageViews.add(message);
+    message.message.scrollIntoView();
   }
 
   void addTags(TagView tag) {
@@ -335,6 +336,7 @@ class ConversationListPanelView {
     activeConversation?._deselect();
     activeConversation = _phoneToConversations[deidentifiedPhoneNumber];
     activeConversation._select();
+    activeConversation.conversationSummary.scrollIntoView();
   }
 
   void clearConversationList() {


### PR DESCRIPTION
A small PR that should make interaction with a large number of conversations/messages more usable by scrolling to the selected conversation (e.g. after filtering conversations, the selected conversation should be in view) and to the last message (e.g. when sending a response, the message list should scroll to show that message)

Thanks!