### PR TITLE
Fix reference to filterConversations

### DIFF
--- a/webapp/lib/controller_view_helper.dart
+++ b/webapp/lib/controller_view_helper.dart
@@ -14,7 +14,7 @@ enum TagReceiver {
 
 void _populateConversationListPanelView(List<model.Conversation> conversations) {
   view.conversationListPanelView.clearConversationList();
-  for (var conversation in filteredConversations) {
+  for (var conversation in conversations) {
     view.conversationListPanelView.addConversation(
       new view.ConversationSummary(
         conversation.deidentifiedPhoneNumber.value,


### PR DESCRIPTION
Hi @lukechurch  - thanks for emailing me about this bug, I think the _populateConversationList[...] method should use the list of conversations given as a parameter rather than the global filteredConversations, even though in practice it's most likely that it will be called with filteredConversations everywhere.