### PR TITLE
Update deploy webapp script

### DIFF
--- a/tool/deploy_webapp.sh
+++ b/tool/deploy_webapp.sh
@@ -41,8 +41,13 @@ cd ..
 # Copy the constants in the build folder
 cp $FIREBASE_CONSTANTS public/assets/firebase_constants.json
 
+########## deploy webapp
+
 # Get the project id
 PROJECT_ID=$(cat $FIREBASE_CONSTANTS | python -c 'import json,sys; constants=json.load(sys.stdin); print(constants["projectId"])')
 
-# Deploy
-firebase deploy --project $PROJECT_ID --public public
+# Deploy using the local firebase instance
+node $PROJDIR/functions/node_modules/.bin/firebase \
+  deploy \
+  --project $PROJECT_ID \
+  --public public


### PR DESCRIPTION
This changes the `deploy_webapp.sh` script to use local version of firebase installed by `npm install` in the `<nook>/functions/node_modules` directory.