### PR TITLE
Model update

### DIFF
--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -17,6 +17,7 @@ class Conversation {
       fromData(doc.data(), modelObj);
 
   static Conversation fromData(data, [Conversation modelObj]) {
+    if (data == null) return null;
     return (modelObj ?? Conversation())
       ..demographicsInfo = Map_fromData<String>(data['demographicsInfo'], String_fromData)
       ..tagIds = List_fromData<String>(data['tags'], String_fromData)
@@ -40,8 +41,9 @@ class Message {
       fromData(doc.data(), modelObj);
 
   static Message fromData(data, [Message modelObj]) {
+    if (data == null) return null;
     return (modelObj ?? Message())
-      ..direction = MessageDirection.fromString(data['direction'] as String)
+      ..direction = MessageDirection.fromString(data['direction'] as String) ?? MessageDirection.Out
       ..datetime = DateTime_fromData(data['datetime']) ?? DateTime.now()
       ..tagIds = List_fromData<String>(data['tags'], String_fromData)
       ..text = String_fromData(data['text'])
@@ -80,6 +82,7 @@ class SuggestedReply {
       fromData(doc.data(), modelObj)..suggestedReplyId = doc.id;
 
   static SuggestedReply fromData(data, [SuggestedReply modelObj]) {
+    if (data == null) return null;
     return (modelObj ?? SuggestedReply())
       ..text = String_fromData(data['text'])
       ..translation = String_fromData(data['translation'])
@@ -101,9 +104,10 @@ class Tag {
       fromData(doc.data(), modelObj)..tagId = doc.id;
 
   static Tag fromData(data, [Tag modelObj]) {
+    if (data == null) return null;
     return (modelObj ?? Tag())
       ..text = String_fromData(data['text'])
-      ..type = TagType.fromString(data['type'] as String)
+      ..type = TagType.fromString(data['type'] as String) ?? TagType.Normal
       ..shortcut = String_fromData(data['shortcut']);
   }
 

--- a/webapp/lib/model.yaml
+++ b/webapp/lib/model.yaml
@@ -5,7 +5,7 @@ Conversation:
   notes: 'string'
 
 Message:
-  direction: 'MessageDirection'
+  direction: 'MessageDirection, MessageDirection.Out'
   datetime: 'datetime, DateTime.now()'
   tags: 'array string tagIds'
   text: 'string'
@@ -27,7 +27,7 @@ SuggestedReply:
 Tag:
   firebaseDocId: 'string tagId'
   text: 'string'
-  type: 'TagType'
+  type: 'TagType, TagType.Normal'
   shortcut: 'string'
 
 TagType:


### PR DESCRIPTION
This updates the model to handle `null` values and allows non-null default values to be specified.
Specifically:
* `Message.direction` defaults to `MessageDirection.out`
* `Tag.type` defaults to `TagType.Normal`

In addition, there is some general cleanup as part of regenerating the model:
* rename `toList` to `List_fromData`
* rename `toMap` to `Map_fromData`
* use `String_fromData` when assigning string fields
* update core type utility methods to gracefully handle `null` values
