### PR TITLE
display system messages

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -225,7 +225,7 @@ void populateUI() {
     (updatedMessages) {
       var updatedIds = updatedMessages.map((m) => m.msgId).toSet();
       systemMessages.removeWhere((m) => updatedIds.contains(m.msgId));
-      systemMessages.addAll(systemMessages.where((m) => !m.expired));
+      systemMessages.addAll(updatedMessages.where((m) => !m.expired));
       command(UIAction.updateSystemMessages, SystemMessagesData(systemMessages));
     });
 }

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -43,6 +43,7 @@ enum UIAction {
   addNewTag,
   enableMultiSelectMode,
   disableMultiSelectMode,
+  updateSystemMessages,
 }
 
 class Data {}
@@ -124,6 +125,11 @@ class AddSuggestedReplyData extends Data {
 class AddTagData extends Data {
   String tagText;
   AddTagData(this.tagText);
+}
+
+class SystemMessagesData extends Data {
+  List<model.SystemMessage> messages;
+  SystemMessagesData(this.messages);
 }
 
 List<model.SystemMessage> systemMessages;
@@ -220,7 +226,7 @@ void populateUI() {
       var updatedIds = updatedMessages.map((m) => m.msgId).toSet();
       systemMessages.removeWhere((m) => updatedIds.contains(m.msgId));
       systemMessages.addAll(systemMessages.where((m) => !m.expired));
-      // TODO display the system messages in a banner
+      command(UIAction.updateSystemMessages, SystemMessagesData(systemMessages));
     });
 }
 
@@ -501,6 +507,15 @@ void command(UIAction action, Data data) {
       view.conversationListPanelView.hideCheckboxes();
       selectedConversations.clear();
       multiSelectMode = false;
+      break;
+    case UIAction.updateSystemMessages:
+      SystemMessagesData msgData = data;
+      if (msgData.messages.isNotEmpty) {
+        var lines = msgData.messages.map((m) => m.text);
+        view.bannerView.showBanner(lines.join(', '));
+      } else {
+        view.bannerView.hideBanner();
+      }
       break;
     default:
   }


### PR DESCRIPTION
This hooks the `SystemMessage` model objects to the banner so that admin-level messages will appear in all clients.

Feel free to land this if the review looks good.