### PR TITLE
replace firestore.WriteBatch with DocUpdate

### DIFF
--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -42,28 +42,28 @@ class Conversation {
 
   DocUpdate updateTagIds(firestore.Firestore fs, String documentPath, List<String> newValue, [DocUpdate batch]) {
     tagIds = newValue;
-    batch ??= FsDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'tags': newValue});
     return batch;
   }
 
   DocUpdate updateMessages(firestore.Firestore fs, String documentPath, List<Message> newValue, [DocUpdate batch]) {
     messages = newValue;
-    batch ??= FsDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'messages': newValue?.map((elem) => elem?.toData())?.toList()});
     return batch;
   }
 
   DocUpdate updateNotes(firestore.Firestore fs, String documentPath, String newValue, [DocUpdate batch]) {
     notes = newValue;
-    batch ??= FsDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'notes': newValue});
     return batch;
   }
 
   DocUpdate updateUnread(firestore.Firestore fs, String documentPath, bool newValue, [DocUpdate batch]) {
     unread = newValue;
-    batch ??= FsDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'unread': newValue});
     return batch;
   }
@@ -108,14 +108,14 @@ class Message {
 
   DocUpdate updateTagIds(firestore.Firestore fs, String documentPath, List<String> newValue, [DocUpdate batch]) {
     tagIds = newValue;
-    batch ??= FsDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'tags': newValue});
     return batch;
   }
 
   DocUpdate updateTranslation(firestore.Firestore fs, String documentPath, String newValue, [DocUpdate batch]) {
     translation = newValue;
-    batch ??= FsDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'translation': newValue});
     return batch;
   }
@@ -221,14 +221,14 @@ class SuggestedReply {
 
   DocUpdate updateText(firestore.Firestore fs, String documentPath, String newValue, [DocUpdate batch]) {
     text = newValue;
-    batch ??= FsDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'text': newValue});
     return batch;
   }
 
   DocUpdate updateTranslation(firestore.Firestore fs, String documentPath, String newValue, [DocUpdate batch]) {
     translation = newValue;
-    batch ??= FsDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'translation': newValue});
     return batch;
   }
@@ -265,21 +265,21 @@ class Tag {
 
   DocUpdate updateText(firestore.Firestore fs, String documentPath, String newValue, [DocUpdate batch]) {
     text = newValue;
-    batch ??= FsDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'text': newValue});
     return batch;
   }
 
   DocUpdate updateType(firestore.Firestore fs, String documentPath, TagType newValue, [DocUpdate batch]) {
     type = newValue;
-    batch ??= FsDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'type': newValue?.toString()});
     return batch;
   }
 
   DocUpdate updateShortcut(firestore.Firestore fs, String documentPath, String newValue, [DocUpdate batch]) {
     shortcut = newValue;
-    batch ??= FsDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'shortcut': newValue});
     return batch;
   }
@@ -441,10 +441,10 @@ abstract class DocUpdate {
 }
 
 /// A batch update for documents in firestore.
-class FsDocUpdate implements DocUpdate {
+class FirestoreDocUpdate implements DocUpdate {
   final firestore.WriteBatch _batch;
 
-  FsDocUpdate(this._batch);
+  FirestoreDocUpdate(this._batch);
 
   @override
   Future<Null> commit() => _batch.commit();

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -40,30 +40,30 @@ class Conversation {
     };
   }
 
-  firestore.WriteBatch updateTagIds(firestore.Firestore fs, String documentPath, List<String> newValue, [firestore.WriteBatch batch]) {
+  DocUpdate updateTagIds(firestore.Firestore fs, String documentPath, List<String> newValue, [DocUpdate batch]) {
     tagIds = newValue;
-    batch ??= fs.batch();
+    batch ??= FsDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'tags': newValue});
     return batch;
   }
 
-  firestore.WriteBatch updateMessages(firestore.Firestore fs, String documentPath, List<Message> newValue, [firestore.WriteBatch batch]) {
+  DocUpdate updateMessages(firestore.Firestore fs, String documentPath, List<Message> newValue, [DocUpdate batch]) {
     messages = newValue;
-    batch ??= fs.batch();
+    batch ??= FsDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'messages': newValue?.map((elem) => elem?.toData())?.toList()});
     return batch;
   }
 
-  firestore.WriteBatch updateNotes(firestore.Firestore fs, String documentPath, String newValue, [firestore.WriteBatch batch]) {
+  DocUpdate updateNotes(firestore.Firestore fs, String documentPath, String newValue, [DocUpdate batch]) {
     notes = newValue;
-    batch ??= fs.batch();
+    batch ??= FsDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'notes': newValue});
     return batch;
   }
 
-  firestore.WriteBatch updateUnread(firestore.Firestore fs, String documentPath, bool newValue, [firestore.WriteBatch batch]) {
+  DocUpdate updateUnread(firestore.Firestore fs, String documentPath, bool newValue, [DocUpdate batch]) {
     unread = newValue;
-    batch ??= fs.batch();
+    batch ??= FsDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'unread': newValue});
     return batch;
   }
@@ -106,16 +106,16 @@ class Message {
     };
   }
 
-  firestore.WriteBatch updateTagIds(firestore.Firestore fs, String documentPath, List<String> newValue, [firestore.WriteBatch batch]) {
+  DocUpdate updateTagIds(firestore.Firestore fs, String documentPath, List<String> newValue, [DocUpdate batch]) {
     tagIds = newValue;
-    batch ??= fs.batch();
+    batch ??= FsDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'tags': newValue});
     return batch;
   }
 
-  firestore.WriteBatch updateTranslation(firestore.Firestore fs, String documentPath, String newValue, [firestore.WriteBatch batch]) {
+  DocUpdate updateTranslation(firestore.Firestore fs, String documentPath, String newValue, [DocUpdate batch]) {
     translation = newValue;
-    batch ??= fs.batch();
+    batch ??= FsDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'translation': newValue});
     return batch;
   }
@@ -219,16 +219,16 @@ class SuggestedReply {
     };
   }
 
-  firestore.WriteBatch updateText(firestore.Firestore fs, String documentPath, String newValue, [firestore.WriteBatch batch]) {
+  DocUpdate updateText(firestore.Firestore fs, String documentPath, String newValue, [DocUpdate batch]) {
     text = newValue;
-    batch ??= fs.batch();
+    batch ??= FsDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'text': newValue});
     return batch;
   }
 
-  firestore.WriteBatch updateTranslation(firestore.Firestore fs, String documentPath, String newValue, [firestore.WriteBatch batch]) {
+  DocUpdate updateTranslation(firestore.Firestore fs, String documentPath, String newValue, [DocUpdate batch]) {
     translation = newValue;
-    batch ??= fs.batch();
+    batch ??= FsDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'translation': newValue});
     return batch;
   }
@@ -263,23 +263,23 @@ class Tag {
     };
   }
 
-  firestore.WriteBatch updateText(firestore.Firestore fs, String documentPath, String newValue, [firestore.WriteBatch batch]) {
+  DocUpdate updateText(firestore.Firestore fs, String documentPath, String newValue, [DocUpdate batch]) {
     text = newValue;
-    batch ??= fs.batch();
+    batch ??= FsDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'text': newValue});
     return batch;
   }
 
-  firestore.WriteBatch updateType(firestore.Firestore fs, String documentPath, TagType newValue, [firestore.WriteBatch batch]) {
+  DocUpdate updateType(firestore.Firestore fs, String documentPath, TagType newValue, [DocUpdate batch]) {
     type = newValue;
-    batch ??= fs.batch();
+    batch ??= FsDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'type': newValue?.toString()});
     return batch;
   }
 
-  firestore.WriteBatch updateShortcut(firestore.Firestore fs, String documentPath, String newValue, [firestore.WriteBatch batch]) {
+  DocUpdate updateShortcut(firestore.Firestore fs, String documentPath, String newValue, [DocUpdate batch]) {
     shortcut = newValue;
-    batch ??= fs.batch();
+    batch ??= FsDocUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'shortcut': newValue});
     return batch;
   }
@@ -417,11 +417,42 @@ void listenForUpdates<T>(
   });
 }
 
+/// A snapshot of a document's id and data at a particular moment in time.
 class DocSnapshot {
   final String id;
   final Map<String, dynamic> data;
 
   DocSnapshot(this.id, this.data);
+}
+
+/// A batch update, used to perform multiple writes as a single atomic unit.
+/// None of the writes are committed (or visible locally) until
+/// [DocUpdate.commit()] is called.
+abstract class DocUpdate {
+  /// Commits all of the writes in this write batch as a single atomic unit.
+  /// Returns non-null [Future] that resolves once all of the writes in the
+  /// batch have been successfully written to the backend as an atomic unit.
+  /// Note that it won't resolve while you're offline.
+  Future<Null> commit();
+
+  /// Updates fields in the document referred to by this [DocumentReference].
+  /// The update will fail if applied to a document that does not exist.
+  void update(firestore.DocumentReference doc, {Map<String, dynamic> data});
+}
+
+/// A batch update for documents in firestore.
+class FsDocUpdate implements DocUpdate {
+  final firestore.WriteBatch _batch;
+
+  FsDocUpdate(this._batch);
+
+  @override
+  Future<Null> commit() => _batch.commit();
+
+  @override
+  void update(firestore.DocumentReference doc, {Map<String, dynamic> data}) {
+    _batch.update(doc, data: data);
+  }
 }
 
 // ======================================================================

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -40,30 +40,30 @@ class Conversation {
     };
   }
 
-  DocUpdate updateTagIds(firestore.Firestore fs, String documentPath, List<String> newValue, [DocUpdate batch]) {
+  DocUpdateBatch updateTagIds(firestore.Firestore fs, String documentPath, List<String> newValue, [DocUpdateBatch batch]) {
     tagIds = newValue;
-    batch ??= FirestoreDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'tags': newValue});
     return batch;
   }
 
-  DocUpdate updateMessages(firestore.Firestore fs, String documentPath, List<Message> newValue, [DocUpdate batch]) {
+  DocUpdateBatch updateMessages(firestore.Firestore fs, String documentPath, List<Message> newValue, [DocUpdateBatch batch]) {
     messages = newValue;
-    batch ??= FirestoreDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'messages': newValue?.map((elem) => elem?.toData())?.toList()});
     return batch;
   }
 
-  DocUpdate updateNotes(firestore.Firestore fs, String documentPath, String newValue, [DocUpdate batch]) {
+  DocUpdateBatch updateNotes(firestore.Firestore fs, String documentPath, String newValue, [DocUpdateBatch batch]) {
     notes = newValue;
-    batch ??= FirestoreDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'notes': newValue});
     return batch;
   }
 
-  DocUpdate updateUnread(firestore.Firestore fs, String documentPath, bool newValue, [DocUpdate batch]) {
+  DocUpdateBatch updateUnread(firestore.Firestore fs, String documentPath, bool newValue, [DocUpdateBatch batch]) {
     unread = newValue;
-    batch ??= FirestoreDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'unread': newValue});
     return batch;
   }
@@ -106,16 +106,16 @@ class Message {
     };
   }
 
-  DocUpdate updateTagIds(firestore.Firestore fs, String documentPath, List<String> newValue, [DocUpdate batch]) {
+  DocUpdateBatch updateTagIds(firestore.Firestore fs, String documentPath, List<String> newValue, [DocUpdateBatch batch]) {
     tagIds = newValue;
-    batch ??= FirestoreDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'tags': newValue});
     return batch;
   }
 
-  DocUpdate updateTranslation(firestore.Firestore fs, String documentPath, String newValue, [DocUpdate batch]) {
+  DocUpdateBatch updateTranslation(firestore.Firestore fs, String documentPath, String newValue, [DocUpdateBatch batch]) {
     translation = newValue;
-    batch ??= FirestoreDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'translation': newValue});
     return batch;
   }
@@ -219,16 +219,16 @@ class SuggestedReply {
     };
   }
 
-  DocUpdate updateText(firestore.Firestore fs, String documentPath, String newValue, [DocUpdate batch]) {
+  DocUpdateBatch updateText(firestore.Firestore fs, String documentPath, String newValue, [DocUpdateBatch batch]) {
     text = newValue;
-    batch ??= FirestoreDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'text': newValue});
     return batch;
   }
 
-  DocUpdate updateTranslation(firestore.Firestore fs, String documentPath, String newValue, [DocUpdate batch]) {
+  DocUpdateBatch updateTranslation(firestore.Firestore fs, String documentPath, String newValue, [DocUpdateBatch batch]) {
     translation = newValue;
-    batch ??= FirestoreDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'translation': newValue});
     return batch;
   }
@@ -263,23 +263,23 @@ class Tag {
     };
   }
 
-  DocUpdate updateText(firestore.Firestore fs, String documentPath, String newValue, [DocUpdate batch]) {
+  DocUpdateBatch updateText(firestore.Firestore fs, String documentPath, String newValue, [DocUpdateBatch batch]) {
     text = newValue;
-    batch ??= FirestoreDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'text': newValue});
     return batch;
   }
 
-  DocUpdate updateType(firestore.Firestore fs, String documentPath, TagType newValue, [DocUpdate batch]) {
+  DocUpdateBatch updateType(firestore.Firestore fs, String documentPath, TagType newValue, [DocUpdateBatch batch]) {
     type = newValue;
-    batch ??= FirestoreDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'type': newValue?.toString()});
     return batch;
   }
 
-  DocUpdate updateShortcut(firestore.Firestore fs, String documentPath, String newValue, [DocUpdate batch]) {
+  DocUpdateBatch updateShortcut(firestore.Firestore fs, String documentPath, String newValue, [DocUpdateBatch batch]) {
     shortcut = newValue;
-    batch ??= FirestoreDocUpdate(fs.batch());
+    batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'shortcut': newValue});
     return batch;
   }
@@ -428,7 +428,7 @@ class DocSnapshot {
 /// A batch update, used to perform multiple writes as a single atomic unit.
 /// None of the writes are committed (or visible locally) until
 /// [DocUpdate.commit()] is called.
-abstract class DocUpdate {
+abstract class DocUpdateBatch {
   /// Commits all of the writes in this write batch as a single atomic unit.
   /// Returns non-null [Future] that resolves once all of the writes in the
   /// batch have been successfully written to the backend as an atomic unit.
@@ -441,10 +441,10 @@ abstract class DocUpdate {
 }
 
 /// A batch update for documents in firestore.
-class FirestoreDocUpdate implements DocUpdate {
+class FirestoreDocUpdateBatch implements DocUpdateBatch {
   final firestore.WriteBatch _batch;
 
-  FirestoreDocUpdate(this._batch);
+  FirestoreDocUpdateBatch(this._batch);
 
   @override
   Future<Null> commit() => _batch.commit();

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -141,14 +141,14 @@ Future updateUnread(List<Conversation> conversations, bool newValue) async {
       : "${conversations.length} conversations"
   }");
   if (conversations.isEmpty) return null;
-  var batch = FirestoreDocUpdate(_firestoreInstance.batch());
+  var batch = FirestoreDocUpdateBatch(_firestoreInstance.batch());
   int batchSize = 0;
   for (var conversation in conversations) {
     conversation.updateUnread(_firestoreInstance, conversation.documentPath, newValue, batch);
     ++batchSize;
     if (batchSize == _MAX_BATCH_SIZE) {
       await batch.commit();
-      batch = FirestoreDocUpdate(_firestoreInstance.batch());
+      batch = FirestoreDocUpdateBatch(_firestoreInstance.batch());
       batchSize = 0;
     }
   }

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -138,13 +138,13 @@ Future updateUnread(List<Conversation> conversations, bool newValue) async {
       : "${conversations.length} conversations"
   }");
   if (conversations.isEmpty) return null;
-  var batch = FsDocUpdate(_firestoreInstance.batch());
+  var batch = FirestoreDocUpdate(_firestoreInstance.batch());
   int batchSize = 0;
   for (var conversation in conversations) {
     conversation.updateUnread(_firestoreInstance, conversation.documentPath, newValue, batch);
     if (batchSize == _MAX_BATCH_SIZE) {
       await batch.commit();
-      batch = FsDocUpdate(_firestoreInstance.batch());
+      batch = FirestoreDocUpdate(_firestoreInstance.batch());
       batchSize = 0;
     }
   }

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -138,13 +138,13 @@ Future updateUnread(List<Conversation> conversations, bool newValue) async {
       : "${conversations.length} conversations"
   }");
   if (conversations.isEmpty) return null;
-  var batch = _firestoreInstance.batch();
+  var batch = FsDocUpdate(_firestoreInstance.batch());
   int batchSize = 0;
   for (var conversation in conversations) {
     conversation.updateUnread(_firestoreInstance, conversation.documentPath, newValue, batch);
     if (batchSize == _MAX_BATCH_SIZE) {
       await batch.commit();
-      batch = _firestoreInstance.batch();
+      batch = FsDocUpdate(_firestoreInstance.batch());
       batchSize = 0;
     }
   }

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -12,6 +12,9 @@ import 'pubsub.dart';
 Logger log = new Logger('platform.dart');
 
 const _SEND_TO_MULTI_IDS_ACTION = "send_to_multi_ids";
+
+/// Each batch of writes can write to a maximum of 500 documents
+/// See https://firebase.google.com/docs/firestore/manage-data/transactions
 const _MAX_BATCH_SIZE = 250;
 
 firestore.Firestore _firestoreInstance;
@@ -142,6 +145,7 @@ Future updateUnread(List<Conversation> conversations, bool newValue) async {
   int batchSize = 0;
   for (var conversation in conversations) {
     conversation.updateUnread(_firestoreInstance, conversation.documentPath, newValue, batch);
+    ++batchSize;
     if (batchSize == _MAX_BATCH_SIZE) {
       await batch.commit();
       batch = FirestoreDocUpdate(_firestoreInstance.batch());


### PR DESCRIPTION
As another step towards [removing firebase from the model](https://github.com/larksystems/Project-2019-WorldBank-PLR/issues/31), this PR replaces `firestore.WriteBatch` with `DocUpdate`.