### PR TITLE
rename some model classes

### DIFF
--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -42,28 +42,28 @@ class Conversation {
     };
   }
 
-  DocUpdateBatch updateTagIds(firestore.Firestore fs, String documentPath, List<String> newValue, [DocUpdateBatch batch]) {
+  DocBatchUpdate updateTagIds(firestore.Firestore fs, String documentPath, List<String> newValue, [DocBatchUpdate batch]) {
     tagIds = newValue;
     batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'tags': newValue});
     return batch;
   }
 
-  DocUpdateBatch updateMessages(firestore.Firestore fs, String documentPath, List<Message> newValue, [DocUpdateBatch batch]) {
+  DocBatchUpdate updateMessages(firestore.Firestore fs, String documentPath, List<Message> newValue, [DocBatchUpdate batch]) {
     messages = newValue;
     batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'messages': newValue?.map((elem) => elem?.toData())?.toList()});
     return batch;
   }
 
-  DocUpdateBatch updateNotes(firestore.Firestore fs, String documentPath, String newValue, [DocUpdateBatch batch]) {
+  DocBatchUpdate updateNotes(firestore.Firestore fs, String documentPath, String newValue, [DocBatchUpdate batch]) {
     notes = newValue;
     batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'notes': newValue});
     return batch;
   }
 
-  DocUpdateBatch updateUnread(firestore.Firestore fs, String documentPath, bool newValue, [DocUpdateBatch batch]) {
+  DocBatchUpdate updateUnread(firestore.Firestore fs, String documentPath, bool newValue, [DocBatchUpdate batch]) {
     unread = newValue;
     batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'unread': newValue});
@@ -108,14 +108,14 @@ class Message {
     };
   }
 
-  DocUpdateBatch updateTagIds(firestore.Firestore fs, String documentPath, List<String> newValue, [DocUpdateBatch batch]) {
+  DocBatchUpdate updateTagIds(firestore.Firestore fs, String documentPath, List<String> newValue, [DocBatchUpdate batch]) {
     tagIds = newValue;
     batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'tags': newValue});
     return batch;
   }
 
-  DocUpdateBatch updateTranslation(firestore.Firestore fs, String documentPath, String newValue, [DocUpdateBatch batch]) {
+  DocBatchUpdate updateTranslation(firestore.Firestore fs, String documentPath, String newValue, [DocBatchUpdate batch]) {
     translation = newValue;
     batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'translation': newValue});
@@ -221,14 +221,14 @@ class SuggestedReply {
     };
   }
 
-  DocUpdateBatch updateText(firestore.Firestore fs, String documentPath, String newValue, [DocUpdateBatch batch]) {
+  DocBatchUpdate updateText(firestore.Firestore fs, String documentPath, String newValue, [DocBatchUpdate batch]) {
     text = newValue;
     batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'text': newValue});
     return batch;
   }
 
-  DocUpdateBatch updateTranslation(firestore.Firestore fs, String documentPath, String newValue, [DocUpdateBatch batch]) {
+  DocBatchUpdate updateTranslation(firestore.Firestore fs, String documentPath, String newValue, [DocBatchUpdate batch]) {
     translation = newValue;
     batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'translation': newValue});
@@ -265,21 +265,21 @@ class Tag {
     };
   }
 
-  DocUpdateBatch updateText(firestore.Firestore fs, String documentPath, String newValue, [DocUpdateBatch batch]) {
+  DocBatchUpdate updateText(firestore.Firestore fs, String documentPath, String newValue, [DocBatchUpdate batch]) {
     text = newValue;
     batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'text': newValue});
     return batch;
   }
 
-  DocUpdateBatch updateType(firestore.Firestore fs, String documentPath, TagType newValue, [DocUpdateBatch batch]) {
+  DocBatchUpdate updateType(firestore.Firestore fs, String documentPath, TagType newValue, [DocBatchUpdate batch]) {
     type = newValue;
     batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'type': newValue?.toString()});
     return batch;
   }
 
-  DocUpdateBatch updateShortcut(firestore.Firestore fs, String documentPath, String newValue, [DocUpdateBatch batch]) {
+  DocBatchUpdate updateShortcut(firestore.Firestore fs, String documentPath, String newValue, [DocBatchUpdate batch]) {
     shortcut = newValue;
     batch ??= FirestoreDocUpdateBatch(fs.batch());
     batch.update(fs.doc(documentPath), data: {'shortcut': newValue});
@@ -453,7 +453,7 @@ class DocSnapshot {
 /// A batch update, used to perform multiple writes as a single atomic unit.
 /// None of the writes are committed (or visible locally) until
 /// [DocUpdate.commit()] is called.
-abstract class DocUpdateBatch {
+abstract class DocBatchUpdate {
   /// Commits all of the writes in this write batch as a single atomic unit.
   /// Returns non-null [Future] that resolves once all of the writes in the
   /// batch have been successfully written to the backend as an atomic unit.
@@ -466,7 +466,7 @@ abstract class DocUpdateBatch {
 }
 
 /// A batch update for documents in firestore.
-class FirestoreDocUpdateBatch implements DocUpdateBatch {
+class FirestoreDocUpdateBatch implements DocBatchUpdate {
   final firestore.WriteBatch _batch;
 
   FirestoreDocUpdateBatch(this._batch);

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -399,7 +399,7 @@ StreamSubscription<List<DocSnapshot>> listenForUpdates<T>(
     ) {
   log.verbose('Loading from $collectionRoot');
   log.verbose('Query root: $collectionRoot');
-  return FirestoreDocStorage(fs).onChange(collectionRoot).listen((List<DocSnapshot> snapshots) {
+  return FirebaseDocStorage(fs).onChange(collectionRoot).listen((List<DocSnapshot> snapshots) {
     List<T> changes = [];
     log.verbose("Starting processing ${snapshots.length} changes.");
     for (var snapshot in snapshots) {
@@ -411,16 +411,16 @@ StreamSubscription<List<DocSnapshot>> listenForUpdates<T>(
 }
 
 /// Document storage interface.
-/// See [FirestoreDocStorage] for a firebase specific version of this.
+/// See [FirebaseDocStorage] for a firebase specific version of this.
 abstract class DocStorage {
   Stream<List<DocSnapshot>> onChange(String collectionRoot);
 }
 
 /// Firebase specific document storage.
-class FirestoreDocStorage implements DocStorage {
+class FirebaseDocStorage implements DocStorage {
   final firestore.Firestore fs;
 
-  FirestoreDocStorage(this.fs);
+  FirebaseDocStorage(this.fs);
 
   @override
   Stream<List<DocSnapshot>> onChange(String collectionRoot) {

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -44,28 +44,28 @@ class Conversation {
 
   DocBatchUpdate updateTagIds(firestore.Firestore fs, String documentPath, List<String> newValue, [DocBatchUpdate batch]) {
     tagIds = newValue;
-    batch ??= FirestoreDocUpdateBatch(fs.batch());
+    batch ??= FirebaseBatchUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'tags': newValue});
     return batch;
   }
 
   DocBatchUpdate updateMessages(firestore.Firestore fs, String documentPath, List<Message> newValue, [DocBatchUpdate batch]) {
     messages = newValue;
-    batch ??= FirestoreDocUpdateBatch(fs.batch());
+    batch ??= FirebaseBatchUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'messages': newValue?.map((elem) => elem?.toData())?.toList()});
     return batch;
   }
 
   DocBatchUpdate updateNotes(firestore.Firestore fs, String documentPath, String newValue, [DocBatchUpdate batch]) {
     notes = newValue;
-    batch ??= FirestoreDocUpdateBatch(fs.batch());
+    batch ??= FirebaseBatchUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'notes': newValue});
     return batch;
   }
 
   DocBatchUpdate updateUnread(firestore.Firestore fs, String documentPath, bool newValue, [DocBatchUpdate batch]) {
     unread = newValue;
-    batch ??= FirestoreDocUpdateBatch(fs.batch());
+    batch ??= FirebaseBatchUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'unread': newValue});
     return batch;
   }
@@ -110,14 +110,14 @@ class Message {
 
   DocBatchUpdate updateTagIds(firestore.Firestore fs, String documentPath, List<String> newValue, [DocBatchUpdate batch]) {
     tagIds = newValue;
-    batch ??= FirestoreDocUpdateBatch(fs.batch());
+    batch ??= FirebaseBatchUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'tags': newValue});
     return batch;
   }
 
   DocBatchUpdate updateTranslation(firestore.Firestore fs, String documentPath, String newValue, [DocBatchUpdate batch]) {
     translation = newValue;
-    batch ??= FirestoreDocUpdateBatch(fs.batch());
+    batch ??= FirebaseBatchUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'translation': newValue});
     return batch;
   }
@@ -223,14 +223,14 @@ class SuggestedReply {
 
   DocBatchUpdate updateText(firestore.Firestore fs, String documentPath, String newValue, [DocBatchUpdate batch]) {
     text = newValue;
-    batch ??= FirestoreDocUpdateBatch(fs.batch());
+    batch ??= FirebaseBatchUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'text': newValue});
     return batch;
   }
 
   DocBatchUpdate updateTranslation(firestore.Firestore fs, String documentPath, String newValue, [DocBatchUpdate batch]) {
     translation = newValue;
-    batch ??= FirestoreDocUpdateBatch(fs.batch());
+    batch ??= FirebaseBatchUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'translation': newValue});
     return batch;
   }
@@ -267,21 +267,21 @@ class Tag {
 
   DocBatchUpdate updateText(firestore.Firestore fs, String documentPath, String newValue, [DocBatchUpdate batch]) {
     text = newValue;
-    batch ??= FirestoreDocUpdateBatch(fs.batch());
+    batch ??= FirebaseBatchUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'text': newValue});
     return batch;
   }
 
   DocBatchUpdate updateType(firestore.Firestore fs, String documentPath, TagType newValue, [DocBatchUpdate batch]) {
     type = newValue;
-    batch ??= FirestoreDocUpdateBatch(fs.batch());
+    batch ??= FirebaseBatchUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'type': newValue?.toString()});
     return batch;
   }
 
   DocBatchUpdate updateShortcut(firestore.Firestore fs, String documentPath, String newValue, [DocBatchUpdate batch]) {
     shortcut = newValue;
-    batch ??= FirestoreDocUpdateBatch(fs.batch());
+    batch ??= FirebaseBatchUpdate(fs.batch());
     batch.update(fs.doc(documentPath), data: {'shortcut': newValue});
     return batch;
   }
@@ -466,10 +466,10 @@ abstract class DocBatchUpdate {
 }
 
 /// A batch update for documents in firestore.
-class FirestoreDocUpdateBatch implements DocBatchUpdate {
+class FirebaseBatchUpdate implements DocBatchUpdate {
   final firestore.WriteBatch _batch;
 
-  FirestoreDocUpdateBatch(this._batch);
+  FirebaseBatchUpdate(this._batch);
 
   @override
   Future<Null> commit() => _batch.commit();

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -141,14 +141,14 @@ Future updateUnread(List<Conversation> conversations, bool newValue) async {
       : "${conversations.length} conversations"
   }");
   if (conversations.isEmpty) return null;
-  var batch = FirestoreDocUpdateBatch(_firestoreInstance.batch());
+  var batch = FirebaseBatchUpdate(_firestoreInstance.batch());
   int batchSize = 0;
   for (var conversation in conversations) {
     conversation.updateUnread(_firestoreInstance, conversation.documentPath, newValue, batch);
     ++batchSize;
     if (batchSize == _MAX_BATCH_SIZE) {
       await batch.commit();
-      batch = FirestoreDocUpdateBatch(_firestoreInstance.batch());
+      batch = FirebaseBatchUpdate(_firestoreInstance.batch());
       batchSize = 0;
     }
   }


### PR DESCRIPTION
This renames 3 model classes
* `DocUpdateBatch` to `DocBatchUpdate`
* `FirestoreDocUpdateBatch` to `FirebaseBatchUpdate`
* `FirestoreDocStorage` to `FirebaseDocStorage`