### PR TITLE
Set main panel widths relative to window width

### DIFF
--- a/webapp/web/messages.css
+++ b/webapp/web/messages.css
@@ -20,6 +20,8 @@
   border-radius: 6px;
   flex: 0 1 auto;
   flex-wrap: inherit;
+  word-wrap: break-word;
+  overflow: hidden;
 }
 
 .message.message--incoming .message__bubble {

--- a/webapp/web/reset.css
+++ b/webapp/web/reset.css
@@ -24,6 +24,7 @@ time, mark, audio, video {
   font: inherit;
   vertical-align: baseline;
   background: transparent;
+  box-sizing: border-box;
 }
 
 html {

--- a/webapp/web/styles.css
+++ b/webapp/web/styles.css
@@ -36,22 +36,18 @@ main {
 .conversation-panel,
 .reply-panel,
 .tag-panel {
-    flex: 1;
     display: flex;
     flex-direction: column;
 }
 
-.conversation-list-panel {
-    width: 300px;
-    border-right: 1px solid #ddd;
-}
-
-.tag-panel {
-    max-width: 300px;
+.conversation-panel {
+    flex: 1;
 }
 
 .conversation-list-panel,
-.reply-panel {
+.reply-panel,
+.tag-panel {
+    width: 20%;
     max-width: 500px;
 }
 
@@ -100,6 +96,10 @@ main {
     background: white;
     padding: 8px;
     margin: 16px;
+}
+
+.conversation-list-panel {
+    border-right: 1px solid #ddd;
 }
 
 .reply-panel,

--- a/webapp/web/styles.css
+++ b/webapp/web/styles.css
@@ -41,14 +41,13 @@ main {
 }
 
 .conversation-panel {
-    flex: 1;
+    width: 40%;
 }
 
 .conversation-list-panel,
 .reply-panel,
 .tag-panel {
     width: 20%;
-    max-width: 500px;
 }
 
 .conversation-list {


### PR DESCRIPTION
Beforehand the size of all panels was done only through flex-box, which made it dependent on the content. This turns out to behave badly when, e.g. there are text messages without spaces on which the line should break.

Fixes #161 