### PR TITLE
Add sample workflow file for automating issues and PRs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,7 @@
+# GitHub Project Automation
+
+If you'd like to automate card creation from GitHub issues and pull requests for this repository using [GitHub Actions](https://help.github.com/en/actions), you can create your own workflow `.yml` file with your name in this folder.
+
+The easiest way to get started is to copy one of the existing files in this folder and replace your name/username throughout the file. Depending on your specific project layout, you may also want to check that the column names are correct.
+
+This workflow uses the [GitHub Project Automation+](https://github.com/marketplace/actions/github-project-automation) Action in order to create the cards in the specified project and column.

--- a/.github/workflows/mariana.yml
+++ b/.github/workflows/mariana.yml
@@ -1,19 +1,40 @@
-name: Move assigned issues and review requests
+name: Add assigned issues and review requests to Mariana's project
 
 on:
   issues:
     types: [assigned]
   pull_request:
-    types: [review_requested]
+    types: [opened, review_requested]
 
 jobs:
   automate-project-columns:
     runs-on: ubuntu-latest
     steps: 
-      - name: Run if the assignee is set as the user
-        if: github.event.issues.assignee == 'marianamarasoiu' || github.event.pull_request.requested_reviewers.contains('marianamarasoiu')
+      - name: Add assigned issues to Mariana's project
+        if: github.event_name == 'issues' &&
+            github.event.assignee.login == 'marianamarasoiu'
         uses: alex-page/github-project-automation-plus@v0.1.2
         with:
           project: Mariana
           column: To do
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_MM_PAT }}
+
+      - name: Add opened pull requests to Mariana's project
+        if: github.event_name == 'pull_request' &&
+            github.event.action == 'opened' &&
+            github.event.pull_request.user.login == 'marianamarasoiu'
+        uses: alex-page/github-project-automation-plus@v0.1.2
+        with:
+          project: Mariana
+          column: In progress
+          repo-token: ${{ secrets.GITHUB_MM_PAT }}
+
+      - name: Add review requests to Mariana's project
+        if: github.event_name == 'pull_request' &&
+            github.event.action == 'review_requested' &&
+            github.event.requested_reviewer.login == 'marianamarasoiu'
+        uses: alex-page/github-project-automation-plus@v0.1.2
+        with:
+          project: Mariana
+          column: To do
+          repo-token: ${{ secrets.GITHUB_MM_PAT }}

--- a/.github/workflows/mariana.yml
+++ b/.github/workflows/mariana.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  issues:
+    types: [assigned]
+  pull_request:
+    types: [review_requested]
+
+jobs:
+  automate-project-columns:
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: alex-page/github-project-automation-plus@v0.1.2
+        with:
+          project: Mariana
+          column: To do
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mariana.yml
+++ b/.github/workflows/mariana.yml
@@ -10,7 +10,9 @@ jobs:
   automate-project-columns:
     runs-on: ubuntu-latest
     steps: 
-      - uses: alex-page/github-project-automation-plus@v0.1.2
+      - name: Run if the assignee is set as the user
+        if: github.event.issues.assignee == 'marianamarasoiu' || github.event.pull_request.requested_reviewers.contains('marianamarasoiu')
+        uses: alex-page/github-project-automation-plus@v0.1.2
         with:
           project: Mariana
           column: To do

--- a/.github/workflows/mariana.yml
+++ b/.github/workflows/mariana.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Move assigned issues and review requests
 
 on:
   issues:


### PR DESCRIPTION
A proposal GitHub workflow for automating the generation of project cards when assigning issues, opening PRs and requesting PR reviews.

I'm not super happy with the solution, but it also seems that this is the best that is available at the moment. Perhaps in the future GitHub will also add automation to adding cards to projects, not just inside projects. In the meantime, please have a look at the code, and here are some of my concerns:


Since there doesn't seem to be a syntax for loops in GitHub workflows, we'll need to list each project/user separately - I was thinking each of us could have our own file.

Another potential downside is that these workflows run per repo, so we would need to import them into each (old and new) repo. I'm not entirely sure whether it's worth littering the codebases with this, and also whether the 'almost' automation that results from this is likely to generate frustration when issues/PRs get ignored because they're not being automatically added to the project.

Since the repos are under larksystems, the workflow needs permissions to run through a personal access token that is stored as a secret on the repo. It seems that we only need one per repo, and so the process of adding one will only need to happen the first time we add a workflow to a repo. (info about this [here](https://github.com/marketplace/actions/github-project-automation)).

Thanks and let me know what you think!

PS. To test this, I've created a separate repo with no code, just the workflows: https://github.com/larksystems/github-actions-test

Feel free to play with it as well :)