### PR TITLE
move firebase specific functionality out of model

### DIFF
--- a/webapp/lib/model.dart
+++ b/webapp/lib/model.dart
@@ -1,7 +1,5 @@
 import 'dart:collection';
 
-import 'package:firebase/firestore.dart' as firestore;
-
 import 'model.g.dart' as g;
 export 'model.g.dart' hide
   Conversation,

--- a/webapp/lib/model_firebase.dart
+++ b/webapp/lib/model_firebase.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+
+import 'package:firebase/firestore.dart' as firestore;
+
+import 'logger.dart';
+import 'model.dart';
+
+Logger log = Logger('model_firebase.dart');
+
+/// Firebase specific document storage.
+class FirebaseDocStorage implements DocStorage {
+  final firestore.Firestore fs;
+
+  FirebaseDocStorage(this.fs);
+
+  @override
+  Stream<List<DocSnapshot>> onChange(String collectionRoot) {
+    return fs
+        .collection(collectionRoot)
+        .onSnapshot
+        .transform<List<DocSnapshot>>(StreamTransformer.fromHandlers(
+      handleData: (firestore.QuerySnapshot querySnapshot,
+          EventSink<List<DocSnapshot>> sink) {
+        // No need to process local writes to Firebase
+        if (querySnapshot.metadata.hasPendingWrites) {
+          log.verbose('Skipping processing of local changes');
+          return;
+        }
+        var event = <DocSnapshot>[];
+        for (var change in querySnapshot.docChanges()) {
+          var doc = change.doc;
+          event.add(DocSnapshot(doc.id, doc.data()));
+        }
+        sink.add(event);
+      },
+    ));
+  }
+
+  @override
+  DocBatchUpdate batch() => _FirebaseBatchUpdate(fs, fs.batch());
+}
+
+/// A batch update for documents in firestore.
+class _FirebaseBatchUpdate implements DocBatchUpdate {
+  final firestore.Firestore _firestore;
+  final firestore.WriteBatch _batch;
+
+  _FirebaseBatchUpdate(this._firestore, this._batch);
+
+  @override
+  Future<Null> commit() => _batch.commit();
+
+  @override
+  void update(String documentPath, {Map<String, dynamic> data}) {
+    _batch.update(_firestore.doc(documentPath), data: data);
+  }
+}

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -6,6 +6,7 @@ import 'package:firebase/firestore.dart' as firestore;
 import 'controller.dart' as controller;
 import 'logger.dart';
 import 'model.dart';
+import 'model_firebase.dart';
 import 'platform_constants.dart' as platform_constants;
 import 'pubsub.dart';
 


### PR DESCRIPTION
This PR finishes moving Firebase specific functionality out of both `model.dart` and `model.g.dart` and into a new `model_firebase.dart` file. This is a step closer to driving nook tests with json rather than firebase.

Fix https://github.com/larksystems/KK-Project-2019-WorldBank-PLR/issues/31