### PR TITLE
new "after date" conversation filter

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -24,9 +24,11 @@ enum UIAction {
   sendMessage,
   addTag,
   addFilterTag,
+  addAfterDateFilter,
   removeConversationTag,
   removeMessageTag,
   removeFilterTag,
+  removeAfterDateFilter,
   showConversation,
   selectConversation,
   deselectConversation,
@@ -142,6 +144,7 @@ List<model.SuggestedReply> suggestedReplies;
 List<model.Tag> conversationTags;
 List<model.Tag> messageTags;
 List<model.Tag> filterTags;
+DateTime afterDateFilter;
 model.Conversation activeConversation;
 List<model.Conversation> selectedConversations;
 model.Message selectedMessage;
@@ -213,7 +216,7 @@ void populateUI() {
       // Get any filter tags from the url
       List<String> filterTagIds = view.urlView.pageUrlFilterTags;
       filterTags = filterTagIds.map((tagId) => conversationTags.singleWhere((tag) => tag.tagId == tagId)).toList();
-      filteredConversations = filterConversationsByTags(conversations, filterTags);
+      filteredConversations = filterConversationsByTags(conversations, filterTags, afterDateFilter);
       _populateFilterTagsMenu(conversationTags);
       _populateSelectedFilterTags(filterTags);
 
@@ -252,6 +255,7 @@ void command(UIAction action, Data data) {
   // Early exist if it's not one of the actions valid without an active conversation.
   if (activeConversation == null &&
       action != UIAction.addFilterTag && action != UIAction.removeFilterTag &&
+      action != UIAction.addAfterDateFilter && action != UIAction.removeAfterDateFilter &&
       action != UIAction.signInButtonClicked && action != UIAction.signOutButtonClicked &&
       action != UIAction.userSignedIn && action != UIAction.userSignedOut) {
     return;
@@ -297,13 +301,15 @@ void command(UIAction action, Data data) {
       filterTags.add(tag);
       view.urlView.pageUrlFilterTags = filterTags.map((tag) => tag.tagId).toList();
       view.conversationFilter.addFilterTag(new view.FilterTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
-      filteredConversations = filterConversationsByTags(conversations, filterTags);
-      activeConversation = updateViewForConversations(filteredConversations);
-      if (multiSelectMode) {
-        view.conversationListPanelView.showCheckboxes();
-        selectedConversations = selectedConversations.toSet().intersection(filteredConversations.toSet()).toList();
-        selectedConversations.forEach((conversation) => view.conversationListPanelView.checkConversation(conversation.deidentifiedPhoneNumber.value));
-      }
+      updateFilteredConversationList();
+      break;
+    case UIAction.addAfterDateFilter:
+      FilterTagData tagData = data;
+      // TODO prompt for new date filter
+      afterDateFilter = DateTime.now();
+      view.conversationFilter.removeFilterTag(tagData.tagId);
+      view.conversationFilter.addFilterTag(new view.DateFilterTagView(afterDateFilter));
+      updateFilteredConversationList();
       break;
     case UIAction.removeConversationTag:
       ConversationTagData conversationTagData = data;
@@ -335,13 +341,13 @@ void command(UIAction action, Data data) {
       filterTags.remove(tag);
       view.urlView.pageUrlFilterTags = filterTags.map((tag) => tag.tagId).toList();
       view.conversationFilter.removeFilterTag(tag.tagId);
-      filteredConversations = filterConversationsByTags(conversations, filterTags);
-      activeConversation = updateViewForConversations(filteredConversations);
-      if (multiSelectMode) {
-        view.conversationListPanelView.showCheckboxes();
-        selectedConversations = selectedConversations.toSet().intersection(filteredConversations.toSet()).toList();
-        selectedConversations.forEach((conversation) => view.conversationListPanelView.checkConversation(conversation.deidentifiedPhoneNumber.value));
-      }
+      updateFilteredConversationList();
+      break;
+    case UIAction.removeAfterDateFilter:
+      FilterTagData tagData = data;
+      afterDateFilter = null;
+      view.conversationFilter.removeFilterTag(tagData.tagId);
+      updateFilteredConversationList();
       break;
     case UIAction.selectMessage:
       MessageData messageData = data;
@@ -521,6 +527,16 @@ void command(UIAction action, Data data) {
   }
 }
 
+void updateFilteredConversationList() {
+  filteredConversations = filterConversationsByTags(conversations, filterTags, afterDateFilter);
+  activeConversation = updateViewForConversations(filteredConversations);
+  if (multiSelectMode) {
+    view.conversationListPanelView.showCheckboxes();
+    selectedConversations = selectedConversations.toSet().intersection(filteredConversations.toSet()).toList();
+    selectedConversations.forEach((conversation) => view.conversationListPanelView.checkConversation(conversation.deidentifiedPhoneNumber.value));
+  }
+}
+
 /// Shows the list of [conversations] and selects the first conversation.
 /// Returns the first conversation in the list, or null if list is empty.
 model.Conversation updateViewForConversations(Set<model.Conversation> conversations) {
@@ -661,12 +677,13 @@ void setMessageTag(model.Tag tag, model.Message message, model.Conversation conv
   }
 }
 
-Set<model.Conversation> filterConversationsByTags(Set<model.Conversation> conversations, List<model.Tag> filterTags) {
-  if (filterTags.isEmpty) return conversations;
+Set<model.Conversation> filterConversationsByTags(Set<model.Conversation> conversations, List<model.Tag> filterTags, DateTime afterDateFilter) {
+  if (filterTags.isEmpty && afterDateFilter == null) return conversations;
 
   var filteredConversations = emptyConversationsSet;
   var filterTagIds = filterTags.map<String>((tag) => tag.tagId).toList();
   conversations.forEach((conversation) {
+    if (afterDateFilter != null && conversation.messages.last.datetime.isBefore(afterDateFilter)) return;
     if (!conversation.tagIds.toSet().containsAll(filterTagIds)) return;
     filteredConversations.add(conversation);
   });

--- a/webapp/lib/controller_view_helper.dart
+++ b/webapp/lib/controller_view_helper.dart
@@ -107,6 +107,7 @@ void _populateFilterTagsMenu(List<model.Tag> tags) {
   for (var tag in tags) {
     view.conversationFilter.addMenuTag(new view.FilterMenuTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
   }
+  view.conversationFilter.addMenuTag(view.AfterDateFilterMenuTagView());
 }
 
 void _populateSelectedFilterTags(List<model.Tag> tags) {

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -185,6 +185,13 @@ class ConversationPanelView {
       _messages.firstChild.remove();
     }
   }
+
+  void showAfterDateFilterPrompt(DateTime dateTime) {
+    log.warning("showAfterDateFilterPrompt");
+    // TODO prompt for after date filter
+    dateTime ??= DateTime.now();
+    command(UIAction.updateAfterDateFilter, new AfterDateFilterData(AFTER_DATE_TAG_ID, dateTime));
+  }
 }
 
 class MessageView {
@@ -378,28 +385,28 @@ class FilterTagView extends TagView {
   }
 }
 
+const AFTER_DATE_TAG_ID = "after-date";
+final DateFormat _afterDateFilterFormat = DateFormat('yyyy.MM.dd HH:mm');
+
 class AfterDateFilterMenuTagView extends FilterMenuTagView {
   AfterDateFilterMenuTagView() : super("after date", AFTER_DATE_TAG_ID, TagStyle.None);
 
   @override
   void handleClicked(String tagId) {
-    command(UIAction.addAfterDateFilter, new FilterTagData(tagId));
+    command(UIAction.promptAfterDateFilter, new AfterDateFilterData(tagId));
   }
 }
 
-const AFTER_DATE_TAG_ID = "after-date";
-final DateFormat _afterDateFormat = DateFormat('yyyy.MM.dd HH:mm');
-
-class DateFilterTagView extends FilterTagView {
-  DateFilterTagView(DateTime dateTime) : super(filterText(dateTime), AFTER_DATE_TAG_ID, TagStyle.None);
+class AfterDateFilterTagView extends FilterTagView {
+  AfterDateFilterTagView(DateTime dateTime) : super(filterText(dateTime), AFTER_DATE_TAG_ID, TagStyle.None);
 
   static String filterText(DateTime dateTime) {
-    return "after date ${_afterDateFormat.format(dateTime)}";
+    return "after date ${_afterDateFilterFormat.format(dateTime)}";
   }
 
   @override
   void handleClicked(String tagId) {
-    command(UIAction.removeAfterDateFilter, new FilterTagData(tagId));
+    command(UIAction.updateAfterDateFilter, new AfterDateFilterData(tagId, null));
   }
 }
 

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -218,7 +218,7 @@ class AfterDateFilterView {
       ..classes.add('after-date-prompt')
       ..append(SpanElement()
         ..classes.add('after-date-prompt__prompt-text')
-        ..text = 'Enter date:')
+        ..text = 'Enter date for "after date" filter:')
       ..append(_textArea)
       ..append(_addButton('Apply')..onClick.listen(applyFilter))
       ..append(_addButton('Cancel')..onClick.listen(hidePrompt));

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -218,7 +218,7 @@ class AfterDateFilterView {
       ..classes.add('after-date-prompt')
       ..append(SpanElement()
         ..classes.add('after-date-prompt__prompt-text')
-        ..text = 'Enter date for "after date" filter:')
+        ..text = 'Enter "after date" filter as yyyy-mm-dd hh:')
       ..append(_textArea)
       ..append(_addButton('Apply')..onClick.listen(applyFilter))
       ..append(_addButton('Cancel')..onClick.listen(hidePrompt));

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -359,16 +359,47 @@ class FilterMenuTagView extends TagView {
   FilterMenuTagView(String text, String tagId, TagStyle tagStyle) : super(text, tagId, tagStyle) {
     _removeButton.remove();
     tag.onClick.listen((_) {
-      command(UIAction.addFilterTag, new FilterTagData(tagId));
+      handleClicked(tagId);
     });
+  }
+
+  void handleClicked(String tagId) {
+    command(UIAction.addFilterTag, new FilterTagData(tagId));
   }
 }
 
 class FilterTagView extends TagView {
   FilterTagView(String text, String tagId, TagStyle tagStyle) : super(text, tagId, tagStyle) {
-    _removeButton..onClick.listen((_) {
-      command(UIAction.removeFilterTag, new FilterTagData(tagId));
-    });
+    _removeButton.onClick.listen((_) => handleClicked(tagId));
+  }
+
+  void handleClicked(String tagId) {
+    command(UIAction.removeFilterTag, new FilterTagData(tagId));
+  }
+}
+
+class AfterDateFilterMenuTagView extends FilterMenuTagView {
+  AfterDateFilterMenuTagView() : super("after date", AFTER_DATE_TAG_ID, TagStyle.None);
+
+  @override
+  void handleClicked(String tagId) {
+    command(UIAction.addAfterDateFilter, new FilterTagData(tagId));
+  }
+}
+
+const AFTER_DATE_TAG_ID = "after-date";
+final DateFormat _afterDateFormat = DateFormat('yyyy.MM.dd HH:mm');
+
+class DateFilterTagView extends FilterTagView {
+  DateFilterTagView(DateTime dateTime) : super(filterText(dateTime), AFTER_DATE_TAG_ID, TagStyle.None);
+
+  static String filterText(DateTime dateTime) {
+    return "after date ${_afterDateFormat.format(dateTime)}";
+  }
+
+  @override
+  void handleClicked(String tagId) {
+    command(UIAction.removeAfterDateFilter, new FilterTagData(tagId));
   }
 }
 

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -231,6 +231,10 @@ class AfterDateFilterView {
     dateTime ??= DateTime.now();
     // TODO populate the fields with dateTime
     panel.classes.add('after-date-prompt__visible');
+    _textArea
+      ..text = _afterDateFilterFormat.format(dateTime)
+      ..setSelectionRange(5, _textArea.text.length)
+      ..focus();
   }
 
   void applyFilter(MouseEvent event) {

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -100,6 +100,7 @@ class ConversationPanelView {
   DivElement _conversationIdCopy;
   DivElement _info;
   DivElement _tags;
+  AfterDateFilterView _afterDateFilterView;
 
   List<MessageView> _messageViews = [];
 
@@ -137,6 +138,9 @@ class ConversationPanelView {
     _messages = new DivElement()
       ..classes.add('messages');
     conversationPanel.append(_messages);
+
+    _afterDateFilterView = AfterDateFilterView();
+    conversationPanel.append(_afterDateFilterView.panel);
   }
 
   set deidentifiedPhoneNumber(String deidentifiedPhoneNumber) => _conversationIdCopy.dataset['copy-value'] = deidentifiedPhoneNumber;
@@ -187,10 +191,45 @@ class ConversationPanelView {
   }
 
   void showAfterDateFilterPrompt(DateTime dateTime) {
-    log.warning("showAfterDateFilterPrompt");
-    // TODO prompt for after date filter
+    _afterDateFilterView.showPrompt(dateTime);
+  }
+}
+
+class AfterDateFilterView {
+  DivElement panel;
+
+  AfterDateFilterView() {
+    panel = DivElement()
+      ..classes.add('after-date-prompt')
+      ..append(_addButton('Apply')..onClick.listen(applyFilter))
+      ..append(_addButton('Cancel')..onClick.listen(hidePrompt));
+  }
+
+  DivElement _addButton(String text) {
+    return DivElement()
+      ..classes.add('after-date-prompt__button')
+      ..append(SpanElement()
+        ..classes.add('after-date-prompt__button-text')
+        ..text = text);
+  }
+
+  void showPrompt(DateTime dateTime) {
+    log.warning("AfterDateFilterView.showPrompt");
     dateTime ??= DateTime.now();
+    // TODO populate the fields with dateTime
+    panel.classes.add('after-date-prompt__visible');
+  }
+
+  void applyFilter(MouseEvent event) {
+    log.warning("AfterDateFilterView.applyFilter");
+    // TODO parse input and apply filter
+    var dateTime = DateTime.now();
     command(UIAction.updateAfterDateFilter, new AfterDateFilterData(AFTER_DATE_TAG_ID, dateTime));
+    hidePrompt();
+  }
+
+  void hidePrompt([_]) {
+    panel.classes.remove('after-date-prompt__visible');
   }
 }
 

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -197,10 +197,23 @@ class ConversationPanelView {
 
 class AfterDateFilterView {
   DivElement panel;
+  TextAreaElement _textArea;
 
   AfterDateFilterView() {
+    _textArea = new TextAreaElement()
+      ..classes.add('after-date-prompt__textarea')
+      ..contentEditable = 'true'
+      ..onInput.listen((e) => e.stopPropagation())
+      ..onKeyDown.listen((e) => e.stopPropagation())
+      ..onKeyUp.listen((e) => e.stopPropagation())
+      ..onKeyPress.listen((e) => e.stopPropagation());
+
     panel = DivElement()
       ..classes.add('after-date-prompt')
+      ..append(SpanElement()
+        ..classes.add('after-date-prompt__prompt-text')
+        ..text = 'Enter date:')
+      ..append(_textArea)
       ..append(_addButton('Apply')..onClick.listen(applyFilter))
       ..append(_addButton('Cancel')..onClick.listen(hidePrompt));
   }

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -206,7 +206,13 @@ class AfterDateFilterView {
       ..onInput.listen((e) => e.stopPropagation())
       ..onKeyDown.listen((e) => e.stopPropagation())
       ..onKeyUp.listen((e) => e.stopPropagation())
-      ..onKeyPress.listen((e) => e.stopPropagation());
+      ..onKeyPress.listen((e) {
+        e.stopPropagation();
+        if (e.keyCode == KeyCode.ENTER) {
+          e.stopImmediatePropagation();
+          applyFilter();
+        }
+      });
 
     panel = DivElement()
       ..classes.add('after-date-prompt')
@@ -236,7 +242,7 @@ class AfterDateFilterView {
       ..focus();
   }
 
-  void applyFilter(MouseEvent event) {
+  void applyFilter([_]) {
     DateTime dateTime;
     try {
       dateTime = parseAfterDateFilterText(_textArea.value);

--- a/webapp/web/styles.css
+++ b/webapp/web/styles.css
@@ -171,28 +171,41 @@ main {
 }
 
 .after-date-prompt {
-  height: 0px;
-  display: flex;
-  flex-direction: row;
-  visibility: hidden;
+    height: 0px;
+    display: flex;
+    flex-direction: row;
+    visibility: hidden;
 }
 
 .after-date-prompt__visible {
-  visibility: visible;
-  height: 24px;
+    visibility: visible;
+    height: 24px;
+}
+
+.after-date-prompt__prompt-text {
+    padding: 2px 5px;
+    margin: 1px 0;
+}
+
+.after-date-prompt__textarea {
+    flex: 1 1 auto;
+    resize: none;
+    color: #555;
+    font-size: 12px;
+    background: #fafafa;
 }
 
 .after-date-prompt__button {
-  font-size: 12px;
-  font-style: italic;
-  display: flex;
+    font-size: 12px;
+    font-style: italic;
+    display: flex;
 }
 
 .after-date-prompt__button-text {
-  padding: 2px 5px;
-  margin: 1px 0;
-  border-radius: 2px;
-  border: 1px solid #ddd;
+    padding: 2px 5px;
+    margin: 1px 0;
+    border-radius: 2px;
+    border: 1px solid #ddd;
 }
 
 .conversation-summary {

--- a/webapp/web/styles.css
+++ b/webapp/web/styles.css
@@ -170,6 +170,31 @@ main {
     border-top: 1px solid #ddd;
 }
 
+.after-date-prompt {
+  height: 0px;
+  display: flex;
+  flex-direction: row;
+  visibility: hidden;
+}
+
+.after-date-prompt__visible {
+  visibility: visible;
+  height: 24px;
+}
+
+.after-date-prompt__button {
+  font-size: 12px;
+  font-style: italic;
+  display: flex;
+}
+
+.after-date-prompt__button-text {
+  padding: 2px 5px;
+  margin: 1px 0;
+  border-radius: 2px;
+  border: 1px solid #ddd;
+}
+
 .conversation-summary {
     text-align: center;
     padding: 4px;


### PR DESCRIPTION
This PR adds a new "after date" filter to show only conversations whose last message has a timestamp more recent than a specified date/time.

![after date filter 1](https://user-images.githubusercontent.com/2891888/73229206-f4df1c00-4146-11ea-934b-711c69c9738a.png)

When selected, a new text area appears in which a date / time can be entered. The format is YYYY MM DD HH. The year is required and must be a contiguous group of 4 digits at the start, but the month, day, and hour are optional and all non-numeric characters entered in this text field will be ignored when parsing the date/time.

![after date filter 2](https://user-images.githubusercontent.com/2891888/73229358-83ec3400-4147-11ea-9248-3dabefdd06f7.png)

When the "Apply" button is clicked or the "Enter" key is pressed, the text is parsed into a date/time and applied as a filter

![after date filter 3](https://user-images.githubusercontent.com/2891888/73229387-a67e4d00-4147-11ea-844a-e0cc68b50a71.png)
