### PR TITLE
Add initial separation between include and exclude filters

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -306,7 +306,7 @@ void command(UIAction action, Data data) {
       if (filterTags.contains(tag)) break;
       filterTags.add(tag);
       view.urlView.pageUrlFilterTags = filterTags.map((tag) => tag.tagId).toList();
-      view.conversationFilter.addFilterTag(new view.FilterTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
+      view.conversationIncludeFilter.addFilterTag(new view.FilterTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
       updateFilteredConversationList();
       break;
     case UIAction.removeConversationTag:
@@ -338,7 +338,7 @@ void command(UIAction action, Data data) {
       model.Tag tag = conversationTags.singleWhere((tag) => tag.tagId == tagData.tagId);
       filterTags.remove(tag);
       view.urlView.pageUrlFilterTags = filterTags.map((tag) => tag.tagId).toList();
-      view.conversationFilter.removeFilterTag(tag.tagId);
+      view.conversationIncludeFilter.removeFilterTag(tag.tagId);
       updateFilteredConversationList();
       break;
     case UIAction.promptAfterDateFilter:
@@ -348,9 +348,9 @@ void command(UIAction action, Data data) {
     case UIAction.updateAfterDateFilter:
       AfterDateFilterData filterData = data;
       afterDateFilter = filterData.afterDateFilter;
-      view.conversationFilter.removeFilterTag(filterData.tagId);
+      view.conversationIncludeFilter.removeFilterTag(filterData.tagId);
       if (afterDateFilter != null) {
-        view.conversationFilter.addFilterTag(new view.AfterDateFilterTagView(afterDateFilter));
+        view.conversationIncludeFilter.addFilterTag(new view.AfterDateFilterTagView(afterDateFilter));
       }
       updateFilteredConversationList();
       break;

--- a/webapp/lib/controller_view_helper.dart
+++ b/webapp/lib/controller_view_helper.dart
@@ -103,17 +103,17 @@ void _populateTagPanelView(List<model.Tag> tags, TagReceiver tagReceiver) {
 }
 
 void _populateFilterTagsMenu(List<model.Tag> tags) {
-  view.conversationFilter.clearMenuTags();
+  view.conversationIncludeFilter.clearMenuTags();
   for (var tag in tags) {
-    view.conversationFilter.addMenuTag(new view.FilterMenuTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
+    view.conversationIncludeFilter.addMenuTag(new view.FilterMenuTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
   }
-  view.conversationFilter.addMenuTag(view.AfterDateFilterMenuTagView());
+  view.conversationIncludeFilter.addMenuTag(view.AfterDateFilterMenuTagView());
 }
 
 void _populateSelectedFilterTags(List<model.Tag> tags) {
-  view.conversationFilter.clearSelectedTags();
+  view.conversationIncludeFilter.clearSelectedTags();
   for (var tag in tags) {
-    view.conversationFilter.addFilterTag(new view.FilterTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
+    view.conversationIncludeFilter.addFilterTag(new view.FilterTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
   }
 }
 

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -12,7 +12,8 @@ import 'lazy_list_view_model.dart';
 Logger log = new Logger('view.dart');
 
 ConversationListPanelView conversationListPanelView;
-ConversationFilter get conversationFilter => conversationListPanelView.conversationFilter;
+ConversationIncludeFilter get conversationIncludeFilter => conversationListPanelView.conversationIncludeFilter;
+ConversationExcludeFilter get conversationExcludeFilter => conversationListPanelView.conversationExcludeFilter;
 ConversationPanelView conversationPanelView;
 ReplyPanelView replyPanelView;
 TagPanelView tagPanelView;
@@ -513,7 +514,8 @@ class ConversationListPanelView {
   CheckboxInputElement _selectAllCheckbox;
   DivElement _loadSpinner;
 
-  ConversationFilter conversationFilter;
+  ConversationIncludeFilter conversationIncludeFilter;
+  ConversationExcludeFilter conversationExcludeFilter;
 
   Map<String, ConversationSummary> _phoneToConversations = {};
   ConversationSummary activeConversation;
@@ -553,8 +555,15 @@ class ConversationListPanelView {
     _conversationList = new LazyListViewModel(conversationListElement);
     conversationListPanel.append(conversationListElement);
 
-    conversationFilter = new ConversationFilter();
-    conversationListPanel.append(conversationFilter.conversationFilter);
+    var conversationFilterContainer = new DivElement()
+      ..classes.add('conversation-filter-container');
+    conversationListPanel.append(conversationFilterContainer);
+
+    conversationIncludeFilter = new ConversationIncludeFilter();
+    conversationFilterContainer.append(conversationIncludeFilter.filterElement);
+
+    conversationExcludeFilter = new ConversationExcludeFilter();
+    conversationFilterContainer.append(conversationExcludeFilter.filterElement);
   }
 
   void addConversation(ConversationSummary conversationSummary, [int position]) {
@@ -614,18 +623,32 @@ class ConversationListPanelView {
 }
 
 class ConversationFilter {
-  DivElement conversationFilter;
+  DivElement filterElement;
+  SpanElement _label;
   DivElement _tagsContainer;
   DivElement _tagsMenu;
   DivElement _tagsMenuContainer;
 
   ConversationFilter() {
-    conversationFilter = new DivElement()
+    filterElement = new DivElement()
       ..classes.add('conversation-filter');
 
-    var descriptionText = new DivElement()
-      ..text = 'Filter conversations ▹';
-    conversationFilter.append(descriptionText);
+    var descriptionText = new DivElement();
+    filterElement.append(descriptionText);
+
+    _label = new SpanElement();
+    descriptionText.append(_label);
+
+    var allOrAny = new SpanElement()
+      ..classes.add('conversation-filter__include__toggle')
+      ..classes.add('conversation-filter__include__toggle--all');
+    allOrAny.onClick.listen((_) {
+      bool any = allOrAny.classes.toggle('conversation-filter__include__toggle--any');
+      allOrAny.classes.toggle('conversation-filter__include__toggle--all', !any);
+      allOrAny.dataset['all-or-any'] = any ? 'any' : 'all';
+      // TODO(mariana): propagate this change to the controller.
+    });
+    descriptionText.append(allOrAny);
 
     _tagsMenu = new DivElement()
       ..classes.add('tags-menu');
@@ -634,11 +657,11 @@ class ConversationFilter {
       ..classes.add('tags-menu__container');
     _tagsMenu.append(_tagsMenuContainer);
 
-    conversationFilter.append(_tagsMenu);
+    filterElement.append(_tagsMenu);
 
     _tagsContainer = new DivElement()
       ..classes.add('tags-container');
-    conversationFilter.append(_tagsContainer);
+    filterElement.append(_tagsContainer);
   }
 
   void addMenuTag(FilterMenuTagView tag) {
@@ -667,6 +690,18 @@ class ConversationFilter {
       _tagsMenuContainer.firstChild.remove();
     }
     assert(_tagsMenuContainer.children.length == 0);
+  }
+}
+
+class ConversationIncludeFilter extends ConversationFilter {
+  ConversationIncludeFilter() {
+    _label.text = 'Show';
+  }
+}
+
+class ConversationExcludeFilter extends ConversationFilter {
+  ConversationExcludeFilter() {
+    _label.text = 'Hide';
   }
 }
 

--- a/webapp/web/styles.css
+++ b/webapp/web/styles.css
@@ -326,3 +326,28 @@ img.partner-logo--unicef {
     margin: 16px 0;
     text-align: center;
 }
+
+/****** Conversation filters *****/
+
+.conversation-filter__include__toggle::before {
+    cursor: pointer;
+    padding: 0 6px;
+    border-right: 1px solid #999;
+    border-bottom: 1px solid #999;
+}
+
+.conversation-filter__include__toggle:hover {
+    background: #eee;
+}
+
+.conversation-filter__include__toggle:active {
+    background: #e6e6e6;
+}
+
+.conversation-filter__include__toggle--all::before {
+    content: 'all';
+}
+
+.conversation-filter__include__toggle--any::before {
+    content: 'any';
+}


### PR DESCRIPTION
Re #189

This is a first step for having two filter lists - one for tags to search for, another for tags to exclude, plus an AND/OR operator on each list.

Currently the exclude list is empty and not functional, that's coming up next.

cc @lukechurch for feedback on the UI approach

Screenshots:
![Screenshot 2020-02-03 at 12 14 58](https://user-images.githubusercontent.com/1173973/73655947-006e9d80-4687-11ea-896d-6680643a0827.png)
![Screenshot 2020-02-03 at 12 15 25](https://user-images.githubusercontent.com/1173973/73655954-03698e00-4687-11ea-83b4-18524e451064.png)
