### PR TITLE
Update unread flag via pub/sub

### DIFF
--- a/webapp/lib/model.dart
+++ b/webapp/lib/model.dart
@@ -65,6 +65,10 @@ class Conversation extends g.Conversation {
     var result = m2.datetime.compareTo(m1.datetime);
     return result != 0 ? result : c2.hashCode.compareTo(c1.hashCode);
   };
+
+  static Future<bool> setAllUnread(g.DocPubSubUpdate pubSubClient, List<Conversation> docs, bool newValue) {
+    g.Conversation.setAllUnread(pubSubClient, docs, newValue);
+  }
 }
 typedef ConversationCollectionListener(List<Conversation> changes);
 

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -10,6 +10,7 @@ Logger log = Logger('model.g.dart');
 class Conversation {
   static const collectionName = 'nook_conversations';
 
+  String docId;
   Map<String, String> demographicsInfo;
   List<String> tagIds;
   List<Message> messages;
@@ -17,7 +18,7 @@ class Conversation {
   bool unread;
 
   static Conversation fromSnapshot(DocSnapshot doc, [Conversation modelObj]) =>
-      fromData(doc.data, modelObj);
+      fromData(doc.data, modelObj)..docId = doc.id;
 
   static Conversation fromData(data, [Conversation modelObj]) {
     if (data == null) return null;

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -71,6 +71,16 @@ class Conversation {
     batch.update(documentPath, data: {'unread': newValue});
     return batch;
   }
+
+  void setUnread(PubSubClient pubSubClient, bool newValue) {
+    unread = newValue;
+    pubSubClient.publish(platform_constants.smsTopic, {
+      "action": "update_firebase",
+      "collection": Conversation.collectionName,
+      "ids": [conversationId],
+      "changes": {"unread": newValue}
+    });
+  }
 }
 typedef void ConversationCollectionListener(List<Conversation> changes);
 

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -66,8 +66,19 @@ class Conversation {
   }
 
   Future<bool> setUnread(DocPubSubUpdate pubSubClient, bool newValue) {
-    unread = newValue;
-    return pubSubClient.publishDocChange(collectionName, [conversationId], {"unread": newValue});
+    return setAllUnread(pubSubClient, [this], newValue);
+  }
+
+  static Future<bool> setAllUnread(DocPubSubUpdate pubSubClient, List<Conversation> docs, bool newValue) async {
+    final docIds = <String>[];
+    for (var doc in docs) {
+      if (doc.unread != newValue) {
+        doc.unread = newValue;
+        docIds.add(doc.docId);
+      }
+    }
+    if (docIds.isEmpty) return true;
+    return pubSubClient.publishDocChange(collectionName, docIds, {"unread": newValue});
   }
 }
 typedef void ConversationCollectionListener(List<Conversation> changes);

--- a/webapp/lib/model.yaml
+++ b/webapp/lib/model.yaml
@@ -5,7 +5,7 @@ Conversation:
   tags: 'updatable array string tagIds'
   messages: 'updatable array Message'
   notes: 'updatable string'
-  unread: 'updatable bool, true'
+  unread: 'publishable bool, true'
 
 Message:
   direction: 'MessageDirection, MessageDirection.Out'

--- a/webapp/lib/model.yaml
+++ b/webapp/lib/model.yaml
@@ -1,5 +1,6 @@
 Conversation:
   firebaseCollectionName: 'nook_conversations'
+  firebaseDocId: 'string docId'
   demographicsInfo: 'map string'
   tags: 'updatable array string tagIds'
   messages: 'updatable array Message'

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -14,10 +14,6 @@ Logger log = new Logger('platform.dart');
 
 const _SEND_TO_MULTI_IDS_ACTION = "send_to_multi_ids";
 
-/// Each batch of writes can write to a maximum of 500 documents
-/// See https://firebase.google.com/docs/firestore/manage-data/transactions
-const _MAX_BATCH_SIZE = 250;
-
 firestore.Firestore _firestoreInstance;
 DocStorage _docStorage;
 PubSubClient _pubsubInstance;
@@ -137,25 +133,15 @@ Future updateNotes(Conversation conversation) {
 }
 
 Future updateUnread(List<Conversation> conversations, bool newValue) async {
-  // TODO consider replacing this with pub/sub
   log.verbose("Updating unread=$newValue for ${
     conversations.length == 1
       ? conversations[0].deidentifiedPhoneNumber.value
       : "${conversations.length} conversations"
   }");
   if (conversations.isEmpty) return null;
-  var batch = _docStorage.batch();
-  int batchSize = 0;
   for (var conversation in conversations) {
-    batch = conversation.updateUnread(_docStorage, conversation.documentPath, newValue, batch);
-    ++batchSize;
-    if (batchSize == _MAX_BATCH_SIZE) {
-      await batch.commit();
-      batch = _docStorage.batch();
-      batchSize = 0;
-    }
+    await conversation.setUnread(_pubsubInstance, newValue);
   }
-  return batch.commit();
 }
 
 Future updateConversationTags(Conversation conversation) {

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -139,9 +139,7 @@ Future updateUnread(List<Conversation> conversations, bool newValue) async {
       : "${conversations.length} conversations"
   }");
   if (conversations.isEmpty) return null;
-  for (var conversation in conversations) {
-    await conversation.setUnread(_pubsubInstance, newValue);
-  }
+  return Conversation.setAllUnread(_pubsubInstance, conversations, newValue);
 }
 
 Future updateConversationTags(Conversation conversation) {

--- a/webapp/lib/pubsub.dart
+++ b/webapp/lib/pubsub.dart
@@ -5,10 +5,12 @@ import 'package:firebase/firebase.dart' as firebase;
 import 'package:http/browser_client.dart';
 
 import 'logger.dart';
+import 'model.dart' show DocPubSubUpdate;
+import 'platform_constants.dart' as platform_constants;
 
 Logger log = new Logger('pubsub.dart');
 
-class PubSubClient {
+class PubSubClient extends DocPubSubUpdate {
   final String publishUrl;
 
   // The firebase user from which the user JWT auth token is obtained.
@@ -36,5 +38,16 @@ class PubSubClient {
 
     log.verbose("publish response ${response.statusCode}, ${response.body}");
     return response.statusCode == 200;
+  }
+
+  @override
+  Future<bool> publishDocChange(String collectionName, List<String> docIds,
+      Map<String, dynamic> changes) {
+    return publish(platform_constants.smsTopic, {
+      "action": "update_firebase",
+      "collection": collectionName,
+      "ids": docIds,
+      "changes": changes,
+    });
   }
 }


### PR DESCRIPTION
This changes the underlying model so that changes to the `Conversation` `unread` flag in firebase are made via pub/sub rather than directly updating firebase.

* `setUnread` - update the `unread` flag for a single conversation
* `setAllUnread` - update the `unread` flag for multiple conversations

A new `DocPubSubUpdate` class (interface) has been added so that the model does not have to know the specifics behind pub/sub implementation.

For background see [reroute nook actions through pub/sub](https://github.com/larksystems/KK-Project-2020-IOM/issues/18)