### PR TITLE
redirect reply.translation to be updated via pub/sub 

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -416,8 +416,12 @@ void command(UIAction action, Data data) {
       break;
     case UIAction.updateTranslation:
       if (data is ReplyTranslationData) {
-        suggestedReplies[data.replyIndex].translation = data.translationText;
-        platform.updateSuggestedReply(suggestedReplies[data.replyIndex]);
+        var reply = suggestedReplies[data.replyIndex];
+        SaveTextAction.textChange(
+          "${reply.docId}.translation",
+          data.translationText,
+          (newText) => platform.updateSuggestedReplyTranslation(reply, newText),
+        );
       } else if (data is TranslationData) {
         TranslationData messageTranslation = data;
         activeConversation.messages[messageTranslation.messageIndex].translation = messageTranslation.translationText;

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -100,9 +100,6 @@ class Message {
   String text;
   String translation;
 
-  static Message fromSnapshot(DocSnapshot doc, [Message modelObj]) =>
-      fromData(doc.data, modelObj);
-
   static Message fromData(data, [Message modelObj]) {
     if (data == null) return null;
     return (modelObj ?? Message())
@@ -113,9 +110,6 @@ class Message {
       ..text = String_fromData(data['text'])
       ..translation = String_fromData(data['translation']);
   }
-
-  static void listen(DocStorage docStorage, MessageCollectionListener listener, String collectionRoot) =>
-      listenForUpdates<Message>(docStorage, listener, collectionRoot, Message.fromSnapshot);
 
   Map<String, dynamic> toData() {
     return {

--- a/webapp/lib/model.yaml
+++ b/webapp/lib/model.yaml
@@ -7,6 +7,7 @@ Conversation:
   unread: 'publishable bool, true'
 
 Message:
+  firebaseDocId: 'none'
   direction: 'MessageDirection, MessageDirection.Out'
   datetime: 'datetime'
   status: MessageStatus

--- a/webapp/lib/model.yaml
+++ b/webapp/lib/model.yaml
@@ -33,8 +33,8 @@ MessageStatus:
 SuggestedReply:
   firebaseCollectionName: 'suggestedReplies'
   firebaseDocId: 'string suggestedReplyId'
-  text: 'updatable string'
-  translation: 'updatable string'
+  text: 'string'
+  translation: 'publishable string'
   shortcut: 'string'
 
 Tag:

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -110,16 +110,9 @@ void listenForMessageTags(TagCollectionListener listener) =>
 void listenForSuggestedReplies(SuggestedReplyCollectionListener listener) =>
     SuggestedReply.listen(_docStorage, listener);
 
-Future updateSuggestedReply(SuggestedReply reply) {
-  log.verbose("Updating suggested Reply ${reply.suggestedReplyId}");
-
-  return _firestoreInstance.doc("${SuggestedReply.collectionName}/${reply.suggestedReplyId}").update(
-    data: {
-      "shortcut" : reply.shortcut,
-      "text" : reply.text,
-      "translation" : reply.translation
-    }
-  );
+Future updateSuggestedReplyTranslation(SuggestedReply reply, String newText) {
+  log.verbose("Updating suggested reply translation ${reply.suggestedReplyId}, '$newText'");
+  return reply.setTranslation(_pubsubInstance, newText);
 }
 
 Future updateConversationMessages(Conversation conversation) {


### PR DESCRIPTION
This builds on the prior [refactor save text action PR](https://github.com/larksystems/nook/pull/202) so that reply.translation changes are consolidated over a rolling 3 second period and updated via pub/sub rather than directly modifying firebase.

In addition, 2 unused `Message` methods were removed.

cc @lukechurch 