### PR TITLE
Bump dart SDK version so we can use extension methods

### DIFF
--- a/webapp/pubspec.yaml
+++ b/webapp/pubspec.yaml
@@ -2,7 +2,7 @@ name: nook
 version: 0.0.1
 
 environment:
-  sdk: ^2.5.0
+  sdk: ^2.7.0
 
 dependencies:
   firebase: ^5.0.0


### PR DESCRIPTION
I'm using extension methods in an upcoming PR - if you don't think it's a good idea to go to Dart 2.7, please let me know and I'm happy to go back.

Thanks!