### PR TITLE
Separate between include and exclude filters

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -306,7 +306,7 @@ void command(UIAction action, Data data) {
       if (filterTags.contains(tag)) break;
       filterTags.add(tag);
       view.urlView.pageUrlFilterTags = filterTags.map((tag) => tag.tagId).toList();
-      view.conversationFilter.addFilterTag(new view.FilterTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
+      view.conversationIncludeFilter.addFilterTag(new view.FilterTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
       updateFilteredConversationList();
       break;
     case UIAction.removeConversationTag:
@@ -338,7 +338,7 @@ void command(UIAction action, Data data) {
       model.Tag tag = conversationTags.singleWhere((tag) => tag.tagId == tagData.tagId);
       filterTags.remove(tag);
       view.urlView.pageUrlFilterTags = filterTags.map((tag) => tag.tagId).toList();
-      view.conversationFilter.removeFilterTag(tag.tagId);
+      view.conversationIncludeFilter.removeFilterTag(tag.tagId);
       updateFilteredConversationList();
       break;
     case UIAction.promptAfterDateFilter:
@@ -348,9 +348,9 @@ void command(UIAction action, Data data) {
     case UIAction.updateAfterDateFilter:
       AfterDateFilterData filterData = data;
       afterDateFilter = filterData.afterDateFilter;
-      view.conversationFilter.removeFilterTag(filterData.tagId);
+      view.conversationIncludeFilter.removeFilterTag(filterData.tagId);
       if (afterDateFilter != null) {
-        view.conversationFilter.addFilterTag(new view.AfterDateFilterTagView(afterDateFilter));
+        view.conversationIncludeFilter.addFilterTag(new view.AfterDateFilterTagView(afterDateFilter));
       }
       updateFilteredConversationList();
       break;

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -173,6 +173,11 @@ class ConversationFilter {
   bool contains(model.Tag tag) {
     return includeTags.contains(tag) || excludeTags.contains(tag);
   }
+
+  bool get isEmpty => includeTags.isEmpty
+                   && excludeTags.isEmpty
+                   && includeAfterDateFilter == null
+                   && excludeAfterDateFilter == null;
 }
 
 List<model.SystemMessage> systemMessages;
@@ -779,12 +784,7 @@ void setMessageTag(model.Tag tag, model.Message message, model.Conversation conv
 }
 
 Set<model.Conversation> filterConversationsByTags(Set<model.Conversation> conversations, ConversationFilter conversationFilter) {
-  if (conversationFilter.includeTags.isEmpty &&
-      conversationFilter.excludeTags.isEmpty &&
-      conversationFilter.includeAfterDateFilter == null &&
-      conversationFilter.excludeAfterDateFilter == null) {
-    return conversations;
-  }
+  if (conversationFilter.isEmpty) return conversations;
 
   var filteredConversations = emptyConversationsSet;
   var includeFilterTagIds = conversationFilter.includeTags.map<String>((tag) => tag.tagId).toSet();

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -290,7 +290,6 @@ ConversationFilter createConversationFilterFromUrl() {
   conversationFilter.excludeLogic = operation ?? ConversationFilter.defaultExcludeLogic;
 
   // after date filter
-  // TODO(mariana): this filter doesn't make it into the URL yet, but it should
   conversationFilter.includeAfterDateFilter = view.urlView.readPageUrlFilterAfterDate(FilterType.include);
   conversationFilter.excludeAfterDateFilter = view.urlView.readPageUrlFilterAfterDate(FilterType.exclude);
 

--- a/webapp/lib/controller_view_helper.dart
+++ b/webapp/lib/controller_view_helper.dart
@@ -103,17 +103,17 @@ void _populateTagPanelView(List<model.Tag> tags, TagReceiver tagReceiver) {
 }
 
 void _populateFilterTagsMenu(List<model.Tag> tags) {
-  view.conversationFilter.clearMenuTags();
+  view.conversationIncludeFilter.clearMenuTags();
   for (var tag in tags) {
-    view.conversationFilter.addMenuTag(new view.FilterMenuTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
+    view.conversationIncludeFilter.addMenuTag(new view.FilterMenuTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
   }
-  view.conversationFilter.addMenuTag(view.AfterDateFilterMenuTagView());
+  view.conversationIncludeFilter.addMenuTag(view.AfterDateFilterMenuTagView());
 }
 
 void _populateSelectedFilterTags(List<model.Tag> tags) {
-  view.conversationFilter.clearSelectedTags();
+  view.conversationIncludeFilter.clearSelectedTags();
   for (var tag in tags) {
-    view.conversationFilter.addFilterTag(new view.FilterTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
+    view.conversationIncludeFilter.addFilterTag(new view.FilterTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
   }
 }
 

--- a/webapp/lib/controller_view_helper.dart
+++ b/webapp/lib/controller_view_helper.dart
@@ -102,18 +102,24 @@ void _populateTagPanelView(List<model.Tag> tags, TagReceiver tagReceiver) {
   }
 }
 
-void _populateFilterTagsMenu(List<model.Tag> tags) {
-  view.conversationIncludeFilter.clearMenuTags();
+void _populateFilterTagsMenu(List<model.Tag> tags, FilterType filterType) {
+  view.ConversationFilterView conversationFilterView = filterType == FilterType.include ? view.conversationIncludeFilter : view.conversationExcludeFilter;
+  conversationFilterView.clearMenuTags();
   for (var tag in tags) {
-    view.conversationIncludeFilter.addMenuTag(new view.FilterMenuTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
+    conversationFilterView.addMenuTag(new view.FilterMenuTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type), filterType));
   }
-  view.conversationIncludeFilter.addMenuTag(view.AfterDateFilterMenuTagView());
+  conversationFilterView.addMenuTag(view.AfterDateFilterMenuTagView(filterType));
 }
 
-void _populateSelectedFilterTags(List<model.Tag> tags) {
+void _populateSelectedFilterTags(ConversationFilter conversationFilter) {
   view.conversationIncludeFilter.clearSelectedTags();
-  for (var tag in tags) {
-    view.conversationIncludeFilter.addFilterTag(new view.FilterTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
+  for (var tag in conversationFilter.includeTags) {
+    view.conversationIncludeFilter.addFilterTag(new view.FilterTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type), FilterType.include));
+  }
+
+  view.conversationExcludeFilter.clearSelectedTags();
+  for (var tag in conversationFilter.excludeTags) {
+    view.conversationExcludeFilter.addFilterTag(new view.FilterTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type), FilterType.exclude));
   }
 }
 

--- a/webapp/lib/controller_view_helper.dart
+++ b/webapp/lib/controller_view_helper.dart
@@ -116,11 +116,19 @@ void _populateSelectedFilterTags(ConversationFilter conversationFilter) {
   for (var tag in conversationFilter.includeTags) {
     view.conversationIncludeFilter.addFilterTag(new view.FilterTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type), FilterType.include));
   }
+  if (conversationFilter.includeAfterDateFilter != null) {
+    view.conversationIncludeFilter.addFilterTag(new view.AfterDateFilterTagView(conversationFilter.includeAfterDateFilter, FilterType.include));
+  }
+  view.conversationIncludeFilter.operation = conversationFilter.includeLogic;
 
   view.conversationExcludeFilter.clearSelectedTags();
   for (var tag in conversationFilter.excludeTags) {
     view.conversationExcludeFilter.addFilterTag(new view.FilterTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type), FilterType.exclude));
   }
+  if (conversationFilter.excludeAfterDateFilter != null) {
+    view.conversationExcludeFilter.addFilterTag(new view.AfterDateFilterTagView(conversationFilter.excludeAfterDateFilter, FilterType.exclude));
+  }
+  view.conversationExcludeFilter.operation = conversationFilter.excludeLogic;
 }
 
 view.TagStyle tagTypeToStyle(model.TagType tagType) {

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -1192,6 +1192,7 @@ class UrlView {
 
   static const String queryFilterKey = 'Filter';
   static const String queryFilterTypeKey = 'Type';
+  static const String queryFilterAfterDateKey = 'AfterDate';
   static const String queryDisableRepliesKey = 'disableReplies';
 
   List<String> readPageUrlFilterTags(FilterType type) {
@@ -1218,8 +1219,8 @@ class UrlView {
     var uri = Uri.parse(window.location.href);
     var queryKey = '${type.value}$queryFilterTypeKey';
     if (uri.queryParameters.containsKey(queryKey)) {
-      String filterType = uri.queryParameters[queryKey];
-      return FilterOperationHelper.fromValue(filterType);
+      String operationType = uri.queryParameters[queryKey];
+      return FilterOperationHelper.fromValue(operationType);
     }
     return null;
   }
@@ -1229,6 +1230,30 @@ class UrlView {
     var queryKey = '${type.value}$queryFilterTypeKey';
     Map<String, String> queryParameters = new Map.from(uri.queryParameters);
     queryParameters[queryKey] = operation.value;
+    uri = uri.replace(queryParameters: queryParameters);
+    window.history.pushState('', '', uri.toString());
+  }
+
+  DateTime readPageUrlFilterAfterDate(FilterType type) {
+    var uri = Uri.parse(window.location.href);
+    var queryKey = '${type.value}$queryFilterAfterDateKey';
+    if (uri.queryParameters.containsKey(queryKey)) {
+      String filterType = uri.queryParameters[queryKey];
+      try {
+        return _afterDateFilterFormat.parse(filterType);
+      } on FormatException catch (e) {
+        snackbarView.showSnackbar("Invalid date/time format for filter in URL: ${e.message}", SnackbarNotificationType.error);
+        return null;
+      }
+    }
+    return null;
+  }
+
+  void writePageUrlFilterAfterDate(FilterType type, DateTime afterDate) {
+    var uri = Uri.parse(window.location.href);
+    var queryKey = '${type.value}$queryFilterAfterDateKey';
+    Map<String, String> queryParameters = new Map.from(uri.queryParameters);
+    queryParameters[queryKey] = _afterDateFilterFormat.format(afterDate);
     uri = uri.replace(queryParameters: queryParameters);
     window.history.pushState('', '', uri.toString());
   }

--- a/webapp/pubspec.yaml
+++ b/webapp/pubspec.yaml
@@ -2,7 +2,7 @@ name: nook
 version: 0.0.1
 
 environment:
-  sdk: ^2.5.0
+  sdk: ^2.7.0
 
 dependencies:
   firebase: ^5.0.0

--- a/webapp/web/styles.css
+++ b/webapp/web/styles.css
@@ -326,3 +326,28 @@ img.partner-logo--unicef {
     margin: 16px 0;
     text-align: center;
 }
+
+/****** Conversation filters *****/
+
+.conversation-filter__include__toggle::before {
+    cursor: pointer;
+    padding: 0 6px;
+    border-right: 1px solid #999;
+    border-bottom: 1px solid #999;
+}
+
+.conversation-filter__include__toggle:hover {
+    background: #eee;
+}
+
+.conversation-filter__include__toggle:active {
+    background: #e6e6e6;
+}
+
+.conversation-filter__include__toggle--all::before {
+    content: 'all';
+}
+
+.conversation-filter__include__toggle--any::before {
+    content: 'any';
+}


### PR DESCRIPTION
Continuing work on more expressive filtering #189 

At the moment, only the tags are considered for the OR/AND operation, the after date is always an AND, even though it's not differentiated in the UI as such. Based on the use cases discussed so far, I think it makes sense to show that its effect is different - @lukechurch can you confirm that this makes sense?

Thanks (and sorry for the slightly extensive change)!

Mini demo:
there are 2 conversations, tagged as follows:

conv1 - tag1
conv2 - tag2

show *any* tag1 tag2:
![Screenshot 2020-02-16 at 21 48 25](https://user-images.githubusercontent.com/1173973/74613471-97673b00-5106-11ea-89e3-885c75c60922.png)

show *all* tag1 tag2:
![Screenshot 2020-02-16 at 21 48 43](https://user-images.githubusercontent.com/1173973/74613467-946c4a80-5106-11ea-9791-1a9fa10cfcf6.png)

hide *all* tag1:
![Screenshot 2020-02-16 at 21 49 05](https://user-images.githubusercontent.com/1173973/74613456-7ef72080-5106-11ea-8ac5-dbebe6f3996a.png)
