### PR TITLE
reroute conversation tag updates through pub/sub

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -312,8 +312,7 @@ void command(UIAction action, Data data) {
     case UIAction.removeConversationTag:
       ConversationTagData conversationTagData = data;
       model.Tag tag = conversationTags.singleWhere((tag) => tag.tagId == conversationTagData.tagId);
-      activeConversation.tagIds.remove(tag.tagId);
-      platform.updateConversationTags(activeConversation);
+      platform.removeConversationTag(activeConversation, tag.tagId);
       view.conversationPanelView.removeTag(tag.tagId);
       if (filterTags.contains(tag)) {
         // Select the next conversation in the list
@@ -662,8 +661,7 @@ void sendMultiReply(model.SuggestedReply reply, List<model.Conversation> convers
 
 void setConversationTag(model.Tag tag, model.Conversation conversation) {
   if (!conversation.tagIds.contains(tag.tagId)) {
-    conversation.tagIds.add(tag.tagId);
-    platform.updateConversationTags(conversation);
+    platform.addConversationTag(conversation, tag.tagId);
     view.conversationPanelView.addTags(new view.ConversationTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
   }
 }
@@ -671,8 +669,7 @@ void setConversationTag(model.Tag tag, model.Conversation conversation) {
 void setMultiConversationTag(model.Tag tag, List<model.Conversation> conversations) {
   conversations.forEach((conversation) {
     if (!conversation.tagIds.contains(tag.tagId)) {
-      conversation.tagIds.add(tag.tagId);
-      platform.updateConversationTags(conversation);
+      platform.addConversationTag(conversation, tag.tagId);
       if (conversation == activeConversation) {
         view.conversationPanelView.addTags(new view.ConversationTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
       }

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -699,7 +699,7 @@ Set<model.Conversation> filterConversationsByTags(Set<model.Conversation> conver
     // Filter by the last (most recent) conversation
     // TODO consider an option to filter by the first conversation
     if (afterDateFilter != null && conversation.messages.last.datetime.isBefore(afterDateFilter)) return;
-    if (!conversation.tagIds.toSet().containsAll(filterTagIds)) return;
+    if (!conversation.tagIds.containsAll(filterTagIds)) return;
     filteredConversations.add(conversation);
   });
   return filteredConversations;

--- a/webapp/lib/model.dart
+++ b/webapp/lib/model.dart
@@ -72,7 +72,7 @@ class Conversation extends g.Conversation {
 }
 typedef ConversationCollectionListener(List<Conversation> changes);
 
-UnmodifiableListView<g.Tag> tagIdsToTags(List<String> tagIds, Iterable<g.Tag> allTags) {
+UnmodifiableListView<g.Tag> tagIdsToTags(Iterable<String> tagIds, Iterable<g.Tag> allTags) {
   var tags = <g.Tag>[];
   for (var id in tagIds) {
     var tag = allTags.firstWhere((tag) => tag.tagId == id, orElse: () {

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -256,13 +256,15 @@ class SuggestedReply {
 typedef void SuggestedReplyCollectionListener(List<SuggestedReply> changes);
 
 class Tag {
-  String tagId;
+  String docId;
   String text;
   TagType type;
   String shortcut;
 
+  String get tagId => docId;
+
   static Tag fromSnapshot(DocSnapshot doc, [Tag modelObj]) =>
-      fromData(doc.data, modelObj)..tagId = doc.id;
+      fromData(doc.data, modelObj)..docId = doc.id;
 
   static Tag fromData(data, [Tag modelObj]) {
     if (data == null) return null;
@@ -340,12 +342,14 @@ TagType Function(String text) TagType_fromStringOverride;
 class SystemMessage {
   static const collectionName = 'systemMessages';
 
-  String msgId;
+  String docId;
   String text;
   bool expired;
 
+  String get msgId => docId;
+
   static SystemMessage fromSnapshot(DocSnapshot doc, [SystemMessage modelObj]) =>
-      fromData(doc.data, modelObj)..msgId = doc.id;
+      fromData(doc.data, modelObj)..docId = doc.id;
 
   static SystemMessage fromData(data, [SystemMessage modelObj]) {
     if (data == null) return null;

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -12,7 +12,7 @@ class Conversation {
 
   String docId;
   Map<String, String> demographicsInfo;
-  List<String> tagIds;
+  Set<String> tagIds;
   List<Message> messages;
   String notes;
   bool unread;
@@ -24,7 +24,7 @@ class Conversation {
     if (data == null) return null;
     return (modelObj ?? Conversation())
       ..demographicsInfo = Map_fromData<String>(data['demographicsInfo'], String_fromData)
-      ..tagIds = List_fromData<String>(data['tags'], String_fromData)
+      ..tagIds = Set_fromData<String>(data['tags'], String_fromData)
       ..messages = List_fromData<Message>(data['messages'], Message.fromData)
       ..notes = String_fromData(data['notes'])
       ..unread = bool_fromData(data['unread']) ?? true;
@@ -37,17 +37,17 @@ class Conversation {
   Map<String, dynamic> toData() {
     return {
       if (demographicsInfo != null) 'demographicsInfo': demographicsInfo,
-      if (tagIds != null) 'tags': tagIds,
+      if (tagIds != null) 'tags': tagIds.toList(),
       if (messages != null) 'messages': messages.map((elem) => elem?.toData()).toList(),
       if (notes != null) 'notes': notes,
       if (unread != null) 'unread': unread,
     };
   }
 
-  DocBatchUpdate updateTagIds(DocStorage docStorage, String documentPath, List<String> newValue, [DocBatchUpdate batch]) {
+  DocBatchUpdate updateTagIds(DocStorage docStorage, String documentPath, Set<String> newValue, [DocBatchUpdate batch]) {
     tagIds = newValue;
     batch ??= docStorage.batch();
-    batch.update(documentPath, data: {'tags': newValue});
+    batch.update(documentPath, data: {'tags': newValue?.toList()});
     return batch;
   }
 
@@ -408,6 +408,9 @@ List<T> List_fromData<T>(dynamic data, T createModel(data)) =>
 
 Map<String, T> Map_fromData<T>(dynamic data, T createModel(data)) =>
     (data as Map)?.map<String, T>((key, value) => MapEntry(key.toString(), createModel(value)));
+
+Set<T> Set_fromData<T>(dynamic data, T createModel(data)) =>
+    (data as List)?.map<T>((elem) => createModel(elem))?.toSet();
 
 StreamSubscription<List<DocSnapshot>> listenForUpdates<T>(
     DocStorage docStorage,

--- a/webapp/lib/model.yaml
+++ b/webapp/lib/model.yaml
@@ -1,7 +1,7 @@
 Conversation:
   firebaseCollectionName: 'nook_conversations'
   demographicsInfo: 'map string'
-  tags: 'updatable set string tagIds'
+  tags: 'publishable set string tagIds'
   messages: 'updatable array Message'
   notes: 'publishable string'
   unread: 'publishable bool, true'

--- a/webapp/lib/model.yaml
+++ b/webapp/lib/model.yaml
@@ -1,7 +1,7 @@
 Conversation:
   firebaseCollectionName: 'nook_conversations'
   demographicsInfo: 'map string'
-  tags: 'updatable array string tagIds'
+  tags: 'updatable set string tagIds'
   messages: 'updatable array Message'
   notes: 'publishable string'
   unread: 'publishable bool, true'

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -133,7 +133,18 @@ Future updateUnread(List<Conversation> conversations, bool newValue) async {
   return Conversation.setAllUnread(_pubsubInstance, conversations, newValue);
 }
 
-Future updateConversationTags(Conversation conversation) {
-  log.verbose("Updating conversation tags for ${conversation.deidentifiedPhoneNumber.value}");
-  return conversation.updateTagIds(_docStorage, conversation.documentPath, conversation.tagIds).commit();
+Future addConversationTag(Conversation conversation, String tagId) {
+  log.verbose("Adding conversation tag $tagId to ${conversation.deidentifiedPhoneNumber.value}");
+  if (!conversation.tagIds.contains(tagId)) {
+    Set<String> newTagIds = Set.from(conversation.tagIds)..add(tagId);
+    return conversation.setTagIds(_pubsubInstance, newTagIds);
+  }
+}
+
+Future removeConversationTag(Conversation conversation, String tagId) {
+  log.verbose("Removing conversation tag $tagId from ${conversation.deidentifiedPhoneNumber.value}");
+  if (conversation.tagIds.contains(tagId)) {
+    Set<String> newTagIds = Set.from(conversation.tagIds)..remove(tagId);
+    return conversation.setTagIds(_pubsubInstance, newTagIds);
+  }
 }


### PR DESCRIPTION
This reroutes changes to `Conversation.tagIds` through pub/sub [rather than modifying firebase directly](https://github.com/larksystems/KK-Project-2020-IOM/issues/18). In addition:
* `Conversation.tagIds` is now a `Set` rather than a `List`
* added `docId` to `SuggestedReply` and `SystemMessage`

Next steps include
* introduce new add/remove pub/sub actions in `pubsub_handler.py`
* rework `addConversationTag` and `removeConversationTag` functions to use the new add/remove pub/sub actions