### PR TITLE
update Conversation.tagIds to use pub/sub add/remove

### DIFF
--- a/webapp/lib/model.dart
+++ b/webapp/lib/model.dart
@@ -67,7 +67,7 @@ class Conversation extends g.Conversation {
   };
 
   static Future addTagId_forAll(g.DocPubSubUpdate pubSubClient, List<Conversation> docs, String newValue) {
-    return g.Conversation.addTagId_forAll(pubSubClient, docs, newValue);
+    return g.Conversation.addToTagIds_forAll(pubSubClient, docs, newValue);
   }
 
   static Future<bool> setUnread_forAll(g.DocPubSubUpdate pubSubClient, List<Conversation> docs, bool newValue) {

--- a/webapp/lib/model.dart
+++ b/webapp/lib/model.dart
@@ -67,7 +67,7 @@ class Conversation extends g.Conversation {
   };
 
   static Future addTagId_forAll(g.DocPubSubUpdate pubSubClient, List<Conversation> docs, String newValue) {
-    return g.Conversation.addToTagIds_forAll(pubSubClient, docs, newValue);
+    return g.Conversation.addToTagId_forAll(pubSubClient, docs, newValue);
   }
 
   static Future<bool> setUnread_forAll(g.DocPubSubUpdate pubSubClient, List<Conversation> docs, bool newValue) {

--- a/webapp/lib/model.dart
+++ b/webapp/lib/model.dart
@@ -66,8 +66,12 @@ class Conversation extends g.Conversation {
     return result != 0 ? result : c2.hashCode.compareTo(c1.hashCode);
   };
 
+  static Future addTagId_forAll(g.DocPubSubUpdate pubSubClient, List<Conversation> docs, String newValue) {
+    return g.Conversation.addTagId_forAll(pubSubClient, docs, newValue);
+  }
+
   static Future<bool> setUnread_forAll(g.DocPubSubUpdate pubSubClient, List<Conversation> docs, bool newValue) {
-    g.Conversation.setUnread_forAll(pubSubClient, docs, newValue);
+    return g.Conversation.setUnread_forAll(pubSubClient, docs, newValue);
   }
 }
 typedef ConversationCollectionListener(List<Conversation> changes);

--- a/webapp/lib/model.dart
+++ b/webapp/lib/model.dart
@@ -66,8 +66,8 @@ class Conversation extends g.Conversation {
     return result != 0 ? result : c2.hashCode.compareTo(c1.hashCode);
   };
 
-  static Future<bool> setAllUnread(g.DocPubSubUpdate pubSubClient, List<Conversation> docs, bool newValue) {
-    g.Conversation.setAllUnread(pubSubClient, docs, newValue);
+  static Future<bool> setUnread_forAll(g.DocPubSubUpdate pubSubClient, List<Conversation> docs, bool newValue) {
+    g.Conversation.setUnread_forAll(pubSubClient, docs, newValue);
   }
 }
 typedef ConversationCollectionListener(List<Conversation> changes);

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -44,20 +44,20 @@ class Conversation {
     };
   }
 
-  Future<bool> addToTagIds(DocPubSubUpdate pubSubClient, String newValue) {
-    return addToTagIds_forAll(pubSubClient, [this], newValue);
+  Future<bool> addToTagId(DocPubSubUpdate pubSubClient, String valueToAdd) {
+    return addToTagId_forAll(pubSubClient, [this], valueToAdd);
   }
 
-  static Future<bool> addToTagIds_forAll(DocPubSubUpdate pubSubClient, List<Conversation> docs, String newValue) async {
-    final docIds = <String>[];
+  static Future<bool> addToTagId_forAll(DocPubSubUpdate pubSubClient, List<Conversation> docs, String valueToAdd) async {
+    final docIdsToPublish = <String>[];
     for (var doc in docs) {
-      if (!doc.tagIds.contains(newValue)) {
-        doc.tagIds.add(newValue);
-        docIds.add(doc.docId);
+      if (!doc.tagIds.contains(valueToAdd)) {
+        doc.tagIds.add(valueToAdd);
+        docIdsToPublish.add(doc.docId);
       }
     }
-    if (docIds.isEmpty) return true;
-    return pubSubClient.publishDocAdd(collectionName, docIds, {"tags": [newValue]});
+    if (docIdsToPublish.isEmpty) return true;
+    return pubSubClient.publishDocAdd(collectionName, docIdsToPublish, {"tags": [valueToAdd]});
   }
 
   Future<bool> setTagIds(DocPubSubUpdate pubSubClient, Set<String> newValue) {
@@ -65,31 +65,31 @@ class Conversation {
   }
 
   static Future<bool> setTagIds_forAll(DocPubSubUpdate pubSubClient, List<Conversation> docs, Set<String> newValue) async {
-    final docIds = <String>[];
+    final docIdsToPublish = <String>[];
     for (var doc in docs) {
       if (doc.tagIds != newValue) {
         doc.tagIds = newValue;
-        docIds.add(doc.docId);
+        docIdsToPublish.add(doc.docId);
       }
     }
-    if (docIds.isEmpty) return true;
-    return pubSubClient.publishDocChange(collectionName, docIds, {"tags": newValue?.toList()});
+    if (docIdsToPublish.isEmpty) return true;
+    return pubSubClient.publishDocChange(collectionName, docIdsToPublish, {"tags": newValue?.toList()});
   }
 
-  Future<bool> removeFromTagIds(DocPubSubUpdate pubSubClient, String newValue) {
-    return removeFromTagIds_forAll(pubSubClient, [this], newValue);
+  Future<bool> removeFromTagId(DocPubSubUpdate pubSubClient, String valueToRemove) {
+    return removeFromTagId_forAll(pubSubClient, [this], valueToRemove);
   }
 
-  static Future<bool> removeFromTagIds_forAll(DocPubSubUpdate pubSubClient, List<Conversation> docs, String oldValue) async {
-    final docIds = <String>[];
+  static Future<bool> removeFromTagId_forAll(DocPubSubUpdate pubSubClient, List<Conversation> docs, String valueToRemove) async {
+    final docIdsToPublish = <String>[];
     for (var doc in docs) {
-      if (doc.tagIds.contains(oldValue)) {
-        doc.tagIds.remove(oldValue);
-        docIds.add(doc.docId);
+      if (doc.tagIds.contains(valueToRemove)) {
+        doc.tagIds.remove(valueToRemove);
+        docIdsToPublish.add(doc.docId);
       }
     }
-    if (docIds.isEmpty) return true;
-    return pubSubClient.publishDocRemove(collectionName, docIds, {"tags": [oldValue]});
+    if (docIdsToPublish.isEmpty) return true;
+    return pubSubClient.publishDocRemove(collectionName, docIdsToPublish, {"tags": [valueToRemove]});
   }
 
   DocBatchUpdate updateMessages(DocStorage docStorage, String documentPath, List<Message> newValue, [DocBatchUpdate batch]) {
@@ -104,15 +104,15 @@ class Conversation {
   }
 
   static Future<bool> setNotes_forAll(DocPubSubUpdate pubSubClient, List<Conversation> docs, String newValue) async {
-    final docIds = <String>[];
+    final docIdsToPublish = <String>[];
     for (var doc in docs) {
       if (doc.notes != newValue) {
         doc.notes = newValue;
-        docIds.add(doc.docId);
+        docIdsToPublish.add(doc.docId);
       }
     }
-    if (docIds.isEmpty) return true;
-    return pubSubClient.publishDocChange(collectionName, docIds, {"notes": newValue});
+    if (docIdsToPublish.isEmpty) return true;
+    return pubSubClient.publishDocChange(collectionName, docIdsToPublish, {"notes": newValue});
   }
 
   Future<bool> setUnread(DocPubSubUpdate pubSubClient, bool newValue) {
@@ -120,15 +120,15 @@ class Conversation {
   }
 
   static Future<bool> setUnread_forAll(DocPubSubUpdate pubSubClient, List<Conversation> docs, bool newValue) async {
-    final docIds = <String>[];
+    final docIdsToPublish = <String>[];
     for (var doc in docs) {
       if (doc.unread != newValue) {
         doc.unread = newValue;
-        docIds.add(doc.docId);
+        docIdsToPublish.add(doc.docId);
       }
     }
-    if (docIds.isEmpty) return true;
-    return pubSubClient.publishDocChange(collectionName, docIds, {"unread": newValue});
+    if (docIdsToPublish.isEmpty) return true;
+    return pubSubClient.publishDocChange(collectionName, docIdsToPublish, {"unread": newValue});
   }
 }
 typedef void ConversationCollectionListener(List<Conversation> changes);
@@ -283,15 +283,15 @@ class SuggestedReply {
   }
 
   static Future<bool> setTranslation_forAll(DocPubSubUpdate pubSubClient, List<SuggestedReply> docs, String newValue) async {
-    final docIds = <String>[];
+    final docIdsToPublish = <String>[];
     for (var doc in docs) {
       if (doc.translation != newValue) {
         doc.translation = newValue;
-        docIds.add(doc.docId);
+        docIdsToPublish.add(doc.docId);
       }
     }
-    if (docIds.isEmpty) return true;
-    return pubSubClient.publishDocChange(collectionName, docIds, {"translation": newValue});
+    if (docIdsToPublish.isEmpty) return true;
+    return pubSubClient.publishDocChange(collectionName, docIdsToPublish, {"translation": newValue});
   }
 }
 typedef void SuggestedReplyCollectionListener(List<SuggestedReply> changes);

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -45,10 +45,10 @@ class Conversation {
   }
 
   Future<bool> setTagIds(DocPubSubUpdate pubSubClient, Set<String> newValue) {
-    return setAllTagIds(pubSubClient, [this], newValue);
+    return setTagIds_forAll(pubSubClient, [this], newValue);
   }
 
-  static Future<bool> setAllTagIds(DocPubSubUpdate pubSubClient, List<Conversation> docs, Set<String> newValue) async {
+  static Future<bool> setTagIds_forAll(DocPubSubUpdate pubSubClient, List<Conversation> docs, Set<String> newValue) async {
     final docIds = <String>[];
     for (var doc in docs) {
       if (doc.tagIds != newValue) {
@@ -68,10 +68,10 @@ class Conversation {
   }
 
   Future<bool> setNotes(DocPubSubUpdate pubSubClient, String newValue) {
-    return setAllNotes(pubSubClient, [this], newValue);
+    return setNotes_forAll(pubSubClient, [this], newValue);
   }
 
-  static Future<bool> setAllNotes(DocPubSubUpdate pubSubClient, List<Conversation> docs, String newValue) async {
+  static Future<bool> setNotes_forAll(DocPubSubUpdate pubSubClient, List<Conversation> docs, String newValue) async {
     final docIds = <String>[];
     for (var doc in docs) {
       if (doc.notes != newValue) {
@@ -84,10 +84,10 @@ class Conversation {
   }
 
   Future<bool> setUnread(DocPubSubUpdate pubSubClient, bool newValue) {
-    return setAllUnread(pubSubClient, [this], newValue);
+    return setUnread_forAll(pubSubClient, [this], newValue);
   }
 
-  static Future<bool> setAllUnread(DocPubSubUpdate pubSubClient, List<Conversation> docs, bool newValue) async {
+  static Future<bool> setUnread_forAll(DocPubSubUpdate pubSubClient, List<Conversation> docs, bool newValue) async {
     final docIds = <String>[];
     for (var doc in docs) {
       if (doc.unread != newValue) {
@@ -247,10 +247,10 @@ class SuggestedReply {
   }
 
   Future<bool> setTranslation(DocPubSubUpdate pubSubClient, String newValue) {
-    return setAllTranslation(pubSubClient, [this], newValue);
+    return setTranslation_forAll(pubSubClient, [this], newValue);
   }
 
-  static Future<bool> setAllTranslation(DocPubSubUpdate pubSubClient, List<SuggestedReply> docs, String newValue) async {
+  static Future<bool> setTranslation_forAll(DocPubSubUpdate pubSubClient, List<SuggestedReply> docs, String newValue) async {
     final docIds = <String>[];
     for (var doc in docs) {
       if (doc.translation != newValue) {

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -44,11 +44,11 @@ class Conversation {
     };
   }
 
-  Future<bool> addTagId(DocPubSubUpdate pubSubClient, String newValue) {
-    return addTagId_forAll(pubSubClient, [this], newValue);
+  Future<bool> addToTagIds(DocPubSubUpdate pubSubClient, String newValue) {
+    return addToTagIds_forAll(pubSubClient, [this], newValue);
   }
 
-  static Future<bool> addTagId_forAll(DocPubSubUpdate pubSubClient, List<Conversation> docs, String newValue) async {
+  static Future<bool> addToTagIds_forAll(DocPubSubUpdate pubSubClient, List<Conversation> docs, String newValue) async {
     final docIds = <String>[];
     for (var doc in docs) {
       if (!doc.tagIds.contains(newValue)) {
@@ -76,20 +76,20 @@ class Conversation {
     return pubSubClient.publishDocChange(collectionName, docIds, {"tags": newValue?.toList()});
   }
 
-  Future<bool> removeTagId(DocPubSubUpdate pubSubClient, String newValue) {
-    return removeTagId_forAll(pubSubClient, [this], newValue);
+  Future<bool> removeFromTagIds(DocPubSubUpdate pubSubClient, String newValue) {
+    return removeFromTagIds_forAll(pubSubClient, [this], newValue);
   }
 
-  static Future<bool> removeTagId_forAll(DocPubSubUpdate pubSubClient, List<Conversation> docs, String newValue) async {
+  static Future<bool> removeFromTagIds_forAll(DocPubSubUpdate pubSubClient, List<Conversation> docs, String oldValue) async {
     final docIds = <String>[];
     for (var doc in docs) {
-      if (doc.tagIds.contains(newValue)) {
-        doc.tagIds.remove(newValue);
+      if (doc.tagIds.contains(oldValue)) {
+        doc.tagIds.remove(oldValue);
         docIds.add(doc.docId);
       }
     }
     if (docIds.isEmpty) return true;
-    return pubSubClient.publishDocRemove(collectionName, docIds, {"tags": [newValue]});
+    return pubSubClient.publishDocRemove(collectionName, docIds, {"tags": [oldValue]});
   }
 
   DocBatchUpdate updateMessages(DocStorage docStorage, String documentPath, List<Message> newValue, [DocBatchUpdate batch]) {

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -57,7 +57,7 @@ class Conversation {
       }
     }
     if (docIds.isEmpty) return true;
-    return pubSubClient.publishDocAdd(collectionName, docIds, {"tags": newValue});
+    return pubSubClient.publishDocAdd(collectionName, docIds, {"tags": [newValue]});
   }
 
   Future<bool> setTagIds(DocPubSubUpdate pubSubClient, Set<String> newValue) {
@@ -84,12 +84,12 @@ class Conversation {
     final docIds = <String>[];
     for (var doc in docs) {
       if (doc.tagIds.contains(newValue)) {
-        doc.tagIds.add(newValue);
+        doc.tagIds.remove(newValue);
         docIds.add(doc.docId);
       }
     }
     if (docIds.isEmpty) return true;
-    return pubSubClient.publishDocRemove(collectionName, docIds, {"tags": newValue});
+    return pubSubClient.publishDocRemove(collectionName, docIds, {"tags": [newValue]});
   }
 
   DocBatchUpdate updateMessages(DocStorage docStorage, String documentPath, List<Message> newValue, [DocBatchUpdate batch]) {
@@ -516,14 +516,14 @@ abstract class DocBatchUpdate {
 /// A pub/sub based mechanism for updating documents
 abstract class DocPubSubUpdate {
   /// Publish the given document list/set additions,
-  /// where [additions] is a mapping of field name to new value to be added to the list/set
-  Future<bool> publishDocAdd(String collectionName, List<String> docIds, Map<String, String> additions);
+  /// where [additions] is a mapping of field name to new values to be added to the list/set
+  Future<bool> publishDocAdd(String collectionName, List<String> docIds, Map<String, List<dynamic>> additions);
 
   /// Publish the given document changes,
   /// where [changes] is a mapping of field name to new value
   Future<bool> publishDocChange(String collectionName, List<String> docIds, Map<String, dynamic> changes);
 
   /// Publish the given document list/set removals,
-  /// where [removals] is a mapping of field name to old value to be removed from the list/set
-  Future<bool> publishDocRemove(String collectionName, List<String> docIds, Map<String, String> removals);
+  /// where [removals] is a mapping of field name to old values to be removed from the list/set
+  Future<bool> publishDocRemove(String collectionName, List<String> docIds, Map<String, List<dynamic>> removals);
 }

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -130,7 +130,7 @@ Future updateUnread(List<Conversation> conversations, bool newValue) async {
       : "${conversations.length} conversations"
   }");
   if (conversations.isEmpty) return null;
-  return Conversation.setAllUnread(_pubsubInstance, conversations, newValue);
+  return Conversation.setUnread_forAll(_pubsubInstance, conversations, newValue);
 }
 
 Future addConversationTag(Conversation conversation, String tagId) {

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -135,7 +135,7 @@ Future updateUnread(List<Conversation> conversations, bool newValue) async {
 
 Future addConversationTag(Conversation conversation, String tagId) {
   log.verbose("Adding tag $tagId to ${conversation.deidentifiedPhoneNumber.value}");
-  return conversation.addTagId(_pubsubInstance, tagId);
+  return conversation.addToTagIds(_pubsubInstance, tagId);
 }
 
 Future addConversationTag_forAll(List<Conversation> conversations, String tagId) {
@@ -145,5 +145,5 @@ Future addConversationTag_forAll(List<Conversation> conversations, String tagId)
 
 Future removeConversationTag(Conversation conversation, String tagId) {
   log.verbose("Removing tag $tagId from ${conversation.deidentifiedPhoneNumber.value}");
-  return conversation.removeTagId(_pubsubInstance, tagId);
+  return conversation.removeFromTagIds(_pubsubInstance, tagId);
 }

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -134,7 +134,7 @@ Future updateUnread(List<Conversation> conversations, bool newValue) async {
 
 Future addConversationTag(Conversation conversation, String tagId) {
   log.verbose("Adding tag $tagId to ${conversation.deidentifiedPhoneNumber.value}");
-  return conversation.addToTagIds(_pubsubInstance, tagId);
+  return conversation.addToTagId(_pubsubInstance, tagId);
 }
 
 Future addConversationTag_forAll(List<Conversation> conversations, String tagId) {
@@ -144,5 +144,5 @@ Future addConversationTag_forAll(List<Conversation> conversations, String tagId)
 
 Future removeConversationTag(Conversation conversation, String tagId) {
   log.verbose("Removing tag $tagId from ${conversation.deidentifiedPhoneNumber.value}");
-  return conversation.removeFromTagIds(_pubsubInstance, tagId);
+  return conversation.removeFromTagId(_pubsubInstance, tagId);
 }

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -1,7 +1,6 @@
 import "dart:async";
 
 import 'package:firebase/firebase.dart' as firebase;
-import 'package:firebase/firestore.dart' as firestore;
 
 import 'controller.dart' as controller;
 import 'logger.dart';

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -134,17 +134,16 @@ Future updateUnread(List<Conversation> conversations, bool newValue) async {
 }
 
 Future addConversationTag(Conversation conversation, String tagId) {
-  log.verbose("Adding conversation tag $tagId to ${conversation.deidentifiedPhoneNumber.value}");
-  if (!conversation.tagIds.contains(tagId)) {
-    Set<String> newTagIds = Set.from(conversation.tagIds)..add(tagId);
-    return conversation.setTagIds(_pubsubInstance, newTagIds);
-  }
+  log.verbose("Adding tag $tagId to ${conversation.deidentifiedPhoneNumber.value}");
+  return conversation.addTagId(_pubsubInstance, tagId);
+}
+
+Future addConversationTag_forAll(List<Conversation> conversations, String tagId) {
+  log.verbose("Adding tag $tagId to ${conversations.length} conversations");
+  return Conversation.addTagId_forAll(_pubsubInstance, conversations, tagId);
 }
 
 Future removeConversationTag(Conversation conversation, String tagId) {
-  log.verbose("Removing conversation tag $tagId from ${conversation.deidentifiedPhoneNumber.value}");
-  if (conversation.tagIds.contains(tagId)) {
-    Set<String> newTagIds = Set.from(conversation.tagIds)..remove(tagId);
-    return conversation.setTagIds(_pubsubInstance, newTagIds);
-  }
+  log.verbose("Removing tag $tagId from ${conversation.deidentifiedPhoneNumber.value}");
+  return conversation.removeTagId(_pubsubInstance, tagId);
 }

--- a/webapp/lib/pubsub.dart
+++ b/webapp/lib/pubsub.dart
@@ -42,7 +42,7 @@ class PubSubClient extends DocPubSubUpdate {
 
   @override
   Future<bool> publishDocAdd(String collectionName, List<String> docIds,
-      Map<String, String> additions) {
+      Map<String, List<dynamic>> additions) {
     return publish(platform_constants.smsTopic, {
       "action": "update_firebase",
       "collection": collectionName,
@@ -64,7 +64,7 @@ class PubSubClient extends DocPubSubUpdate {
 
   @override
   Future<bool> publishDocRemove(String collectionName, List<String> docIds,
-      Map<String, String> removals) {
+      Map<String, List<dynamic>> removals) {
     return publish(platform_constants.smsTopic, {
       "action": "update_firebase",
       "collection": collectionName,

--- a/webapp/lib/pubsub.dart
+++ b/webapp/lib/pubsub.dart
@@ -41,6 +41,17 @@ class PubSubClient extends DocPubSubUpdate {
   }
 
   @override
+  Future<bool> publishDocAdd(String collectionName, List<String> docIds,
+      Map<String, String> additions) {
+    return publish(platform_constants.smsTopic, {
+      "action": "update_firebase",
+      "collection": collectionName,
+      "ids": docIds,
+      "additions": additions,
+    });
+  }
+
+  @override
   Future<bool> publishDocChange(String collectionName, List<String> docIds,
       Map<String, dynamic> changes) {
     return publish(platform_constants.smsTopic, {
@@ -48,6 +59,17 @@ class PubSubClient extends DocPubSubUpdate {
       "collection": collectionName,
       "ids": docIds,
       "changes": changes,
+    });
+  }
+
+  @override
+  Future<bool> publishDocRemove(String collectionName, List<String> docIds,
+      Map<String, String> removals) {
+    return publish(platform_constants.smsTopic, {
+      "action": "update_firebase",
+      "collection": collectionName,
+      "ids": docIds,
+      "removals": removals,
     });
   }
 }


### PR DESCRIPTION
This updates `Conversation.tagIds` to use the new pub/sub based add to and remove from list operations. In addition `setAll<fieldName>` is renamed to `set<fieldName>_forAll`

See [reroute nook actions through pub/sub](https://github.com/larksystems/KK-Project-2020-IOM/issues/18)