### PR TITLE
Show last message not first in conversation summary

### DIFF
--- a/webapp/lib/controller_view_helper.dart
+++ b/webapp/lib/controller_view_helper.dart
@@ -20,7 +20,7 @@ void _populateConversationListPanelView(Set<model.Conversation> conversations) {
       view.conversationListPanelView.addConversation(
           new view.ConversationSummary(
               conversation.deidentifiedPhoneNumber.value,
-              conversation.messages.first.text,
+              conversation.messages.last.text,
               conversation.unread)
       );
     }


### PR DESCRIPTION
Fixes #159 

I think in the future we'll want to have an indicator in the conversation list as to who sent the last message (ie. us via Nook or the person we're talking to), or we may want to always show the last message of the conversant and never from us, but for now, showing the last message should be an improvement.

cc @lukechurch 