### PR TITLE
Add support for two views in preparation of adding an outbox feature

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -194,7 +194,6 @@ void initUI() {
       conversationTags.removeWhere((tag) => updatedIds.contains(tag.tagId));
       conversationTags.addAll(tags);
       _populateFilterTagsMenu(conversationTags);
-      print(actionObjectState);
       if (actionObjectState == UIActionObject.conversation) {
         _populateTagPanelView(conversationTags, TagReceiver.Conversation);
       }

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -46,6 +46,12 @@ enum UIAction {
   enableMultiSelectMode,
   disableMultiSelectMode,
   updateSystemMessages,
+  switchView,
+}
+
+enum UIView {
+  conversations,
+  outbox,
 }
 
 class Data {}
@@ -140,9 +146,15 @@ class SystemMessagesData extends Data {
   SystemMessagesData(this.messages);
 }
 
+class SwitchViewData extends Data {
+  UIView view;
+  SwitchViewData(this.view);
+}
+
 List<model.SystemMessage> systemMessages;
 
 UIActionObject actionObjectState;
+UIView viewState;
 
 Set<model.Conversation> conversations;
 Set<model.Conversation> filteredConversations;
@@ -159,6 +171,8 @@ model.User signedInUser;
 bool multiSelectMode;
 
 void init() async {
+  viewState = UIView.conversations;
+  actionObjectState = UIActionObject.conversation;
   view.init();
   await platform.init();
 }
@@ -180,7 +194,7 @@ void initUI() {
       conversationTags.removeWhere((tag) => updatedIds.contains(tag.tagId));
       conversationTags.addAll(tags);
       _populateFilterTagsMenu(conversationTags);
-
+      print(actionObjectState);
       if (actionObjectState == UIActionObject.conversation) {
         _populateTagPanelView(conversationTags, TagReceiver.Conversation);
       }
@@ -258,6 +272,25 @@ model.Conversation nextElement(Iterable<model.Conversation> conversations, model
 }
 
 void command(UIAction action, Data data) {
+  if (action == UIAction.switchView) {
+    SwitchViewData viewData = data;
+    if (viewState == viewData.view) return;
+    viewState = viewData.view;
+    view.showSignedInView(viewState);
+    return;
+  }
+
+  switch (viewState) {
+    case UIView.conversations:
+      conversationCommand(action, data);
+      break;
+    case UIView.outbox:
+      outboxCommand(action, data);
+      break;
+  }
+}
+
+void conversationCommand(UIAction action, Data data) {
   // For most actions, a conversation needs to be active.
   // Early exist if it's not one of the actions valid without an active conversation.
   if (activeConversation == null &&
@@ -438,7 +471,7 @@ void command(UIAction action, Data data) {
     case UIAction.userSignedOut:
       signedInUser = null;
       view.authHeaderView.signOut();
-      view.initSignedOutView();
+      view.showSignedOutView();
       break;
     case UIAction.userSignedIn:
       UserData userData = data;
@@ -446,7 +479,7 @@ void command(UIAction action, Data data) {
         ..userName = userData.displayName
         ..userEmail = userData.email;
       view.authHeaderView.signIn(userData.displayName, userData.photoUrl);
-      view.initSignedInView();
+      view.showSignedInView(viewState);
       initUI();
       break;
     case UIAction.signInButtonClicked:
@@ -538,6 +571,10 @@ void command(UIAction action, Data data) {
       break;
     default:
   }
+}
+
+void outboxCommand(UIAction action, Data data) {
+  print('outbox commands not implemented yet');
 }
 
 void updateFilteredConversationList() {

--- a/webapp/web/styles.css
+++ b/webapp/web/styles.css
@@ -23,7 +23,7 @@ header {
     display: flex;
     align-items: stretch;
     flex-direction: row;
-    justify-content: flex-end;
+    justify-content: space-between;
 }
 
 main {
@@ -280,6 +280,51 @@ main {
     color: #555;
     font-size: 12px;
     background: #fafafa;
+}
+
+.menu {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    margin: 0 6px;
+}
+
+.title {
+    font-weight: 900;
+    font-size: 18px;
+    line-height: 27px;
+    color: #666;
+    padding: 0 16px 0 8px;
+}
+
+.menu__buttons {
+    display: flex;
+    align-items: center;
+}
+
+.menu__button {
+    padding: 3px 12px 12px;
+    margin-top: 11px;
+    cursor: pointer;
+    border: 1px solid white;
+    border-bottom: none;
+    border-top-width: 3px;
+}
+
+.menu__button.menu__button--selected {
+    border-color: #ddd;
+}
+
+.menu__button:hover {
+    background-color: #f9f9f9;
+    border-bottom: 1px solid #ddd;
+    padding-bottom: 11px;
+}
+
+.menu__button:active {
+    background-color: #eee;
+    border-bottom: 1px solid #ddd;
+    padding-bottom: 11px;
 }
 
 .auth {


### PR DESCRIPTION
Re #162 

This creates a top menu for switching between the conversation view (the UI we already have) and the outbox, an upcoming new view for managing outgoing messages (delayed sending to allow double checking, scheduled sending etc.)

As with the filtering feature, because it's a substantial change and intermediate versions might not work, I'm working on a separate branch off master (`dev-outbox`) which when ready, I'll merge into master.

cc @lukechurch for following progress and feedback on UI design

Demo: 
![Screenshot 2020-02-27 at 16 22 02](https://user-images.githubusercontent.com/1173973/75463435-bd4dd480-597d-11ea-8d2b-f02b1642bc31.png)
![Screenshot 2020-02-27 at 16 22 42](https://user-images.githubusercontent.com/1173973/75463452-c2128880-597d-11ea-8e0d-9f4da6e13087.png)
