### PR TITLE
initialize actionObjectState

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -142,7 +142,7 @@ class SystemMessagesData extends Data {
 
 List<model.SystemMessage> systemMessages;
 
-UIActionObject actionObjectState;
+UIActionObject actionObjectState = UIActionObject.conversation;
 
 Set<model.Conversation> conversations;
 Set<model.Conversation> filteredConversations;


### PR DESCRIPTION
If I launch nook and I am already signed in (which I typically am) then it immediately displays the conversation view (which I think is correct), but the tags view on the right is empty. If I sign out then back in, the tags appear and all is well.

After digging I found that if the `actionObjecState` is not initialized, then the tags view on the right is empty. This PR adds that initialization so that the tags show up without having to log out then back in again.