### PR TITLE
Update message tags and translation via pub/sub

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -425,15 +425,23 @@ void command(UIAction action, Data data) {
         );
       } else if (data is TranslationData) {
         TranslationData messageTranslation = data;
-        var message = activeConversation.messages[messageTranslation.messageIndex];
-        platform.setMessageTranslation(activeConversation, message, messageTranslation.translationText);
+        var conversation = activeConversation;
+        var message = conversation.messages[messageTranslation.messageIndex];
+        SaveTextAction.textChange(
+          "${conversation.docId}.message-${messageTranslation.messageIndex}.translation",
+          messageTranslation.translationText,
+          (newText) {
+            return platform.setMessageTranslation(conversation, message, newText);
+          },
+        );
       }
       break;
     case UIAction.updateNote:
+      var conversation = activeConversation;
       SaveTextAction.textChange(
-        "${activeConversation.docId}.notes",
+        "${conversation.docId}.notes",
         (data as NoteData).noteText,
-        (newText) => platform.updateNotes(activeConversation, newText),
+        (newText) => platform.updateNotes(conversation, newText),
       );
       break;
     case UIAction.userSignedOut:
@@ -681,7 +689,7 @@ void setMultiConversationTag(model.Tag tag, List<model.Conversation> conversatio
 
 void setMessageTag(model.Tag tag, model.Message message, model.Conversation conversation) {
   if (!message.tagIds.contains(tag.tagId)) {
-    platform.addMessageTag(activeConversation, message, tag.tagId);
+    platform.addMessageTag(activeConversation, message, tag.tagId).catchError(showAndLogError);
     view.conversationPanelView
       .messageViewAtIndex(conversation.messages.indexOf(message))
       .addTag(new view.MessageTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -329,8 +329,7 @@ void command(UIAction action, Data data) {
     case UIAction.removeMessageTag:
       MessageTagData messageTagData = data;
       var message = activeConversation.messages[messageTagData.messageIndex];
-      message.tagIds.removeWhere((id) => id == messageTagData.tagId);
-      platform.updateConversationMessages(activeConversation);
+      platform.removeMessageTag(activeConversation, message, messageTagData.tagId).catchError(showAndLogError);
       view.conversationPanelView
         .messageViewAtIndex(messageTagData.messageIndex)
         .removeTag(messageTagData.tagId);
@@ -426,8 +425,8 @@ void command(UIAction action, Data data) {
         );
       } else if (data is TranslationData) {
         TranslationData messageTranslation = data;
-        activeConversation.messages[messageTranslation.messageIndex].translation = messageTranslation.translationText;
-        platform.updateConversationMessages(activeConversation);
+        var message = activeConversation.messages[messageTranslation.messageIndex];
+        platform.setMessageTranslation(activeConversation, message, messageTranslation.translationText);
       }
       break;
     case UIAction.updateNote:
@@ -682,8 +681,7 @@ void setMultiConversationTag(model.Tag tag, List<model.Conversation> conversatio
 
 void setMessageTag(model.Tag tag, model.Message message, model.Conversation conversation) {
   if (!message.tagIds.contains(tag.tagId)) {
-    message.tagIds.add(tag.tagId);
-    platform.updateConversationMessages(activeConversation);
+    platform.addMessageTag(activeConversation, message, tag.tagId);
     view.conversationPanelView
       .messageViewAtIndex(conversation.messages.indexOf(message))
       .addTag(new view.MessageTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -436,13 +436,15 @@ void command(UIAction action, Data data) {
         );
       }
       break;
-    case UIAction.updateNote:
-      var conversation = activeConversation;
-      SaveTextAction.textChange(
-        "${conversation.docId}.notes",
-        (data as NoteData).noteText,
-        (newText) => platform.updateNotes(conversation, newText),
-      );
+    case UIAction.updateNote: {
+        // inside block to ensure conversation is a local/captured var
+        var conversation = activeConversation;
+        SaveTextAction.textChange(
+          "${conversation.docId}.notes",
+          (data as NoteData).noteText,
+          (newText) => platform.updateNotes(conversation, newText),
+        );
+      }
       break;
     case UIAction.userSignedOut:
       signedInUser = null;

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -104,13 +104,6 @@ class Conversation {
     return pubSubClient.publishDocRemove(collectionName, docIdsToPublish, {"tags": [tagId]});
   }
 
-  DocBatchUpdate updateMessages(DocStorage docStorage, String documentPath, List<Message> newValue, [DocBatchUpdate batch]) {
-    messages = newValue;
-    batch ??= docStorage.batch();
-    batch.update(documentPath, data: {'messages': newValue?.map((elem) => elem?.toData())?.toList()});
-    return batch;
-  }
-
   /// Set notes in this Conversation.
   /// Callers should catch and handle IOException.
   Future<void> setNotes(DocPubSubUpdate pubSubClient, String notes) {
@@ -181,20 +174,6 @@ class Message {
       if (text != null) 'text': text,
       if (translation != null) 'translation': translation,
     };
-  }
-
-  DocBatchUpdate updateTagIds(DocStorage docStorage, String documentPath, List<String> newValue, [DocBatchUpdate batch]) {
-    tagIds = newValue;
-    batch ??= docStorage.batch();
-    batch.update(documentPath, data: {'tags': newValue});
-    return batch;
-  }
-
-  DocBatchUpdate updateTranslation(DocStorage docStorage, String documentPath, String newValue, [DocBatchUpdate batch]) {
-    translation = newValue;
-    batch ??= docStorage.batch();
-    batch.update(documentPath, data: {'translation': newValue});
-    return batch;
   }
 }
 typedef void MessageCollectionListener(List<Message> changes);

--- a/webapp/lib/model.yaml
+++ b/webapp/lib/model.yaml
@@ -2,7 +2,7 @@ Conversation:
   firebaseCollectionName: 'nook_conversations'
   demographicsInfo: 'map string'
   tags: 'publishable set string tagIds'
-  messages: 'updatable array Message'
+  messages: 'array Message'
   notes: 'publishable string'
   unread: 'publishable bool, true'
 
@@ -11,9 +11,9 @@ Message:
   direction: 'MessageDirection, MessageDirection.Out'
   datetime: 'datetime'
   status: MessageStatus
-  tags: 'updatable array string tagIds'
+  tags: 'array string tagIds'
   text: 'string'
-  translation: 'updatable string'
+  translation: 'string'
 
 MessageDirection:
   dartType: 'enum'

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -112,9 +112,19 @@ Future<void> updateSuggestedReplyTranslation(SuggestedReply reply, String newTex
   return reply.setTranslation(_pubsubInstance, newText);
 }
 
-Future updateConversationMessages(Conversation conversation) {
-  log.verbose("Updating conversation messages for ${conversation.docId}");
-  return conversation.updateMessages(_docStorage, conversation.documentPath, conversation.messages).commit();
+Future<void> addMessageTag(Conversation conversation, Message message, String tagId) {
+  log.verbose("Adding tag $tagId to message in conversation ${conversation.docId}");
+  return message.addTagId(_pubsubInstance, conversation, tagId);
+}
+
+Future<void> removeMessageTag(Conversation conversation, Message message, String tagId) {
+  log.verbose("Removing tag $tagId from message in conversation ${conversation.docId}");
+  return message.removeTagId(_pubsubInstance, conversation, tagId);
+}
+
+Future<void> setMessageTranslation(Conversation conversation, Message message, String translation) {
+  log.verbose("Set translation for message in conversation ${conversation.docId}");
+  return message.setTranslation(_pubsubInstance, conversation, translation);
 }
 
 Future<void> updateNotes(Conversation conversation, String updatedText) {


### PR DESCRIPTION
This updates the controller, platform, and model to use pub/sub when
* adding a message tag
* removing a message tag
* updating a message translation

In addition, updating a message translation now uses `SaveTextAction` similar to updating a conversation note.

Fix https://github.com/larksystems/KK-Project-2020-IOM/issues/18