### PR TITLE
Remove reference to dart:io libary from web platform code

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -2,7 +2,6 @@ library controller;
 
 import 'dart:async';
 import 'dart:collection';
-import 'dart:io';
 
 import 'logger.dart';
 import 'model.dart' as model;
@@ -775,8 +774,6 @@ void showAndLogError(error, trace) {
   String errMsg;
   if (error is PubSubException) {
     errMsg = "A network problem occurred: ${error.message}";
-  } else if (error is IOException) {
-    errMsg = "A network problem occurred: ${error.runtimeType}";
   } else if (error is Exception) {
     errMsg = "An internal error occurred: ${error.runtimeType}";
   } else {

--- a/webapp/lib/pubsub.dart
+++ b/webapp/lib/pubsub.dart
@@ -1,6 +1,5 @@
 import "dart:async";
 import "dart:convert";
-import 'dart:io';
 
 import 'package:firebase/firebase.dart' as firebase;
 import 'package:http/browser_client.dart';
@@ -79,7 +78,7 @@ class PubSubClient extends DocPubSubUpdate {
   }
 }
 
-class PubSubException implements IOException {
+class PubSubException implements Exception {
   final String message;
 
   static fromResponse(Response response) =>


### PR DESCRIPTION
I think the `dart:io` library got introduced accidentally In #217 and I didn't catch it in review either, resulting in the app not compiling any more.

Is there a particular reason why `PubSubException` should inherit from `IOException`, or can it inherit directly from `Exception`? If it's not too important, here's a simple PR to remove the `dart:io` imports and remove `IOException`, but if you would like to do this a different way, happy to discuss.

Thanks!
