### PR TITLE
Propagate void return type from pubsub, remove exception handling in controller

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -634,11 +634,7 @@ void sendReply(model.SuggestedReply reply, model.Conversation conversation) {
       translation: newMessage.translation,
       incoming: false)
   );
-  platform
-    .sendMessage(conversation.docId, reply.text)
-    .then((success) {
-      log.verbose('controller.sendMessage reponse status $success');
-    });
+  platform.sendMessage(conversation.docId, reply.text);
 }
 
 void sendMultiReply(model.SuggestedReply reply, List<model.Conversation> conversations) {
@@ -661,11 +657,7 @@ void sendMultiReply(model.SuggestedReply reply, List<model.Conversation> convers
     );
   }
   List<String> ids = conversations.map((conversation) => conversation.docId).toList();
-  platform
-    .sendMultiMessage(ids, newMessage.text)
-    .then((success) {
-      log.verbose('controller.sendMultiMessage reponse status $success');
-    });
+  platform.sendMultiMessage(ids, newMessage.text);
 }
 
 void setConversationTag(model.Tag tag, model.Conversation conversation) {

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -63,13 +63,13 @@ bool isUserSignedIn() {
   return firebaseAuth.currentUser != null;
 }
 
-Future<bool> sendMessage(String id, String message) {
+Future<void> sendMessage(String id, String message) {
   log.verbose("Sending message $id : $message");
 
   return sendMultiMessage([id], message);
 }
 
-Future<bool> sendMultiMessage(List<String> ids, String message) {
+Future<void> sendMultiMessage(List<String> ids, String message) {
   log.verbose("Sending multi-message $ids : $message");
 
   //  {


### PR DESCRIPTION
Follow on from #217 which changed the return type of the pubsub methods to `Future<void>`, this does the same for the platform methods, otherwise the following error appears whenever a message is sent from the UI:
`Uncaught Error: Type '_Future<void>' should be '_Future<bool>' to implement expected type 'Future<bool>'.`

It seems that the static type checking isn't catching `Future<T>` differences in return type.