### PR TITLE
improve scrolling in conversation list

### DIFF
--- a/webapp/lib/lazy_list_view_model.dart
+++ b/webapp/lib/lazy_list_view_model.dart
@@ -13,7 +13,7 @@ class LazyListViewModel {
 
   /// The DOM element used to display the items
   /// and typically displaying only a subset of the items.
-  final _listView;
+  final DivElement _listView;
 
   /// The vertical scroll distance of the DOM elements in the [_listView] in pixels.
   int _scrollLength = 0;
@@ -21,6 +21,12 @@ class LazyListViewModel {
   /// The width of the [_listView] scrolling area in pixels
   /// or `null` if it has not been cached yet.
   int _scrollWidth = 10;
+
+  /// A DOM element used to pad the height of the scroll list
+  /// so that scrolling approximates the list size
+  /// without adding all of the individual DOM elements
+  final _scrollPad = DivElement();
+  static const _scollPadMinHeight = 30;
 
   /// When the width of the scrolling area changes,
   /// a delayed [Future] is created to recalculate [_scrollLength].
@@ -61,12 +67,14 @@ class LazyListViewModel {
     var position = _items.indexOf(item);
     // Add additional elements to the DOM as necessary
     // so that the conversation can be selected.
+    _scrollPad.remove();
     while (position >= _listView.children.length) {
       _listView.append(_items[_listView.children.length].element);
     }
     if (position >= 0) {
       item.element.scrollIntoView();
     }
+    _updateScrollPad();
   }
 
   /// Update the [LazyListViewItem] elements cached/displayed in the DOM
@@ -80,18 +88,38 @@ class LazyListViewModel {
       // If the scroll area width changed, then recalculate the scroll length
       // because the item heights and thus the scroll length depends upon the scroll area width.
       _scrollLengthRecalc ??= new Future.delayed(const Duration(seconds: 2), () {
-        _scrollLength = _listView.children.fold(0, (len, element) => len + element.clientHeight);
+        _scrollLength = _listView.children.fold(0, (len, element)
+            => element == _scrollPad ? _scollPadMinHeight : len + element.clientHeight);
         _scrollWidth = _listView.clientWidth;
         _scrollLengthRecalc = null;
       });
     }
 
+    _scrollPad.remove();
     var desiredScrollLength = _listView.scrollTop + 3 * _listView.clientHeight;
     while (_scrollLength < desiredScrollLength && _listView.children.length < _items.length) {
       var item = _items[_listView.children.length];
       _listView.append(item.element);
       _scrollLength += item.element.clientHeight;
     }
+    _updateScrollPad();
+  }
+
+  void _updateScrollPad() {
+    _scrollPad.remove();
+    int padHeight;
+    if (_listView.children.length < _items.length) {
+      // Add a DOM element to pad the height of the scroll list
+      // so that scrolling approximates the list size
+      // without adding all of the individual DOM elements
+      double aveItemHeight = _listView.scrollHeight / _listView.children.length;
+      int numItemsInPad = _items.length - _listView.children.length;
+      padHeight = aveItemHeight.floor() * numItemsInPad;
+    } else {
+      padHeight = _scollPadMinHeight;
+    }
+    _scrollPad.style.height = "${padHeight}px";
+    _listView.append(_scrollPad);
   }
 
   void _windowResized(_ignored_) {

--- a/webapp/lib/lazy_list_view_model.dart
+++ b/webapp/lib/lazy_list_view_model.dart
@@ -16,7 +16,7 @@ class LazyListViewModel {
   final DivElement _listView;
 
   /// The vertical scroll distance of the DOM elements in the [_listView] in pixels.
-  int _scrollLength = _scollPadMinHeight;
+  int _scrollLength = _scrollPadMinHeight;
 
   /// The width of the [_listView] scrolling area in pixels
   /// or `null` if it has not been cached yet.
@@ -26,7 +26,7 @@ class LazyListViewModel {
   /// so that scrolling approximates the list size
   /// without adding all of the individual DOM elements
   final _scrollPad = DivElement();
-  static const _scollPadMinHeight = 30;
+  static const _scrollPadMinHeight = 30;
 
   /// When the width of the scrolling area changes,
   /// a delayed [Future] is created to recalculate [_scrollLength].
@@ -61,7 +61,7 @@ class LazyListViewModel {
     _scrollPad.remove();
     assert(_listView.children.length == 0);
     _items.clear();
-    _scrollLength = _scollPadMinHeight;
+    _scrollLength = _scrollPadMinHeight;
   }
 
   void selectItem(LazyListViewItem item) {
@@ -90,7 +90,7 @@ class LazyListViewModel {
       // because the item heights and thus the scroll length depends upon the scroll area width.
       _scrollLengthRecalc ??= new Future.delayed(const Duration(seconds: 2), () {
         _scrollLength = _listView.children.fold(0, (len, element)
-            => element == _scrollPad ? _scollPadMinHeight : len + element.clientHeight);
+            => element == _scrollPad ? _scrollPadMinHeight : len + element.clientHeight);
         _scrollWidth = _listView.clientWidth;
         _scrollLengthRecalc = null;
       });
@@ -117,7 +117,7 @@ class LazyListViewModel {
       int numItemsInPad = _items.length - _listView.children.length;
       padHeight = aveItemHeight.floor() * numItemsInPad;
     } else {
-      padHeight = _scollPadMinHeight;
+      padHeight = _scrollPadMinHeight;
     }
     _scrollPad.style.height = "${padHeight}px";
     _listView.append(_scrollPad);

--- a/webapp/lib/lazy_list_view_model.dart
+++ b/webapp/lib/lazy_list_view_model.dart
@@ -16,7 +16,7 @@ class LazyListViewModel {
   final DivElement _listView;
 
   /// The vertical scroll distance of the DOM elements in the [_listView] in pixels.
-  int _scrollLength = 0;
+  int _scrollLength = _scollPadMinHeight;
 
   /// The width of the [_listView] scrolling area in pixels
   /// or `null` if it has not been cached yet.
@@ -58,9 +58,10 @@ class LazyListViewModel {
     for (var item in _items) {
       item.disposeElement();
     }
+    _scrollPad.remove();
     assert(_listView.children.length == 0);
     _items.clear();
-    _scrollLength = 0;
+    _scrollLength = _scollPadMinHeight;
   }
 
   void selectItem(LazyListViewItem item) {


### PR DESCRIPTION
This improves the scrolling in the lazily loaded conversations list by adding a single `_scrollPad` DOM element representing the not-yet-loaded DOM elements. The size of this DOM element is dynamically updated as new elements are loaded resulting in a scroll bar that closely approximates behavior if all of the elements were loaded. It also results in a small non-item white area at the end of the list so that you now can tell that you have indeed scrolled to the end and there are no more items.

Hopefully this will improve https://github.com/larksystems/nook/issues/256

Feel free to merge this PR if it proves helpful.