### PR TITLE
update conversation list in place when processing updates from firebase

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -283,7 +283,7 @@ void initUI() {
       _populateFilterTagsMenu(_filterAgeTagsIfNeeded(conversationTags));
       _populateSelectedFilterTags(filterTags);
 
-      activeConversation = updateViewForConversations(filteredConversations);
+      activeConversation = updateViewForConversations(filteredConversations, updateList: true);
       if (activeConversation == null) return;
 
       // Update the active conversation view as needed
@@ -660,11 +660,12 @@ void updateFilteredConversationList() {
   }
 }
 
-/// Shows the list of [conversations] and selects the first conversation.
+/// Shows the list of [conversations] and selects the first conversation
+/// where [updateList] is `true` if this list can be updated in place.
 /// Returns the first conversation in the list, or null if list is empty.
-model.Conversation updateViewForConversations(Set<model.Conversation> conversations) {
+model.Conversation updateViewForConversations(Set<model.Conversation> conversations, {bool updateList = false}) {
   // Update conversationListPanelView
-  _populateConversationListPanelView(conversations);
+  _populateConversationListPanelView(conversations, updateList);
 
   // Update conversationPanelView
   if (conversations.isEmpty) {

--- a/webapp/lib/controller_view_helper.dart
+++ b/webapp/lib/controller_view_helper.dart
@@ -14,18 +14,13 @@ enum TagReceiver {
 
 // Functions to populate the views with model objects.
 
-void _populateConversationListPanelView(Set<model.Conversation> conversations) {
-  view.conversationListPanelView.clearConversationList();
+void _populateConversationListPanelView(Set<model.Conversation> conversations, bool updateList) {
   view.conversationListPanelView.hideLoadSpinner();
-  if (conversations.isNotEmpty) {
-    for (var conversation in conversations) {
-      view.conversationListPanelView.addConversation(
-          new view.ConversationSummary(
-              conversation.docId,
-              conversation.messages.first.text,
-              conversation.unread)
-      );
-    }
+  if (conversations.isEmpty || !updateList) {
+    view.conversationListPanelView.clearConversationList();
+  }
+  for (var conversation in conversations) {
+    view.conversationListPanelView.addOrUpdateConversation(conversation);
   }
 }
 

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:intl/intl.dart';
+import 'package:nook/model.dart';
 
 import 'dom_utils.dart';
 import 'logger.dart';
@@ -603,10 +604,23 @@ class ConversationListPanelView {
     conversationListPanel.append(conversationFilter.conversationFilter);
   }
 
-  void addConversation(ConversationSummary conversationSummary, [int position]) {
-    _conversationList.addItem(conversationSummary, position);
-    _phoneToConversations[conversationSummary.deidentifiedPhoneNumber] = conversationSummary;
-    _conversationPanelTitle.text = '${_phoneToConversations.length} conversations';
+  void addOrUpdateConversation(Conversation conversation) {
+    ConversationSummary summary = _phoneToConversations[conversation.docId];
+    if (summary != null) {
+      if (conversation.unread) {
+        summary._markUnread();
+      } else {
+        summary._markRead();
+      }
+    } else {
+      summary = new ConversationSummary(
+              conversation.docId,
+              conversation.messages.first.text,
+              conversation.unread);
+      _conversationList.addItem(summary, null);
+      _phoneToConversations[summary.deidentifiedPhoneNumber] = summary;
+      _conversationPanelTitle.text = '${_phoneToConversations.length} conversations';
+    }
   }
 
   void selectConversation(String deidentifiedPhoneNumber) {


### PR DESCRIPTION
This modifies firebase update processing so that conversation summaries in the conversation list are updated in place rather than recomputing the entire list each time a new conversation update arrives.

Hopefully addresses https://github.com/larksystems/nook/issues/257

Feel free to squash/merge this if it is helpful.