### PR TITLE
Remove item from DOM via removal from lazy list

### DIFF
--- a/webapp/lib/lazy_list_view_model.dart
+++ b/webapp/lib/lazy_list_view_model.dart
@@ -78,6 +78,13 @@ class LazyListViewModel {
     _updateScrollPad();
   }
 
+  void removeItem(LazyListViewItem item) {
+    _items.remove(item);
+    item.disposeElement();
+    _scrollPad.remove();
+    _updateScrollPad();
+  }
+
   /// Update the [LazyListViewItem] elements cached/displayed in the DOM
   /// based on the scroll position "scrollTop",
   /// the length of the cached/displayed DOM elements "scrollLength",

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -634,7 +634,7 @@ class ConversationListPanelView {
   void updateConversationList(Set<Conversation> conversations) {
     _phoneToConversations.removeWhere((String uuid, ConversationSummary summary) {
       if (conversations.any((c) => c.docId == uuid)) return false;
-      summary.elementOrNull?.remove();
+      _conversationList.removeItem(summary);
       return true;
     });
     for (var conversation in conversations) {


### PR DESCRIPTION
Removing an item from DOM only resulted in the item not getting added back to the DOM if it needed to get back into the list. This now syncs the DOM list with the lazy list by removing the element from the DOM via the lazy list.

@danrubel In particular, does the update of the scrollPad in `removeItem` make sense? Should I be doing anything else when removing an item from the list?

Thanks!