### PR TITLE
Hide conversation list selector until fully implemented

### DIFF
--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -45,7 +45,8 @@ void init() {
 }
 
 void initSignedInView() {
-  conversationListSelectView.panel.style.visibility = 'visible';
+  // TODO(mariana): Set visibility to hidden for now whilst the table selector isn't functional
+  conversationListSelectView.panel.style.visibility = 'hidden';
   clearMain();
 
   querySelector('main')
@@ -564,7 +565,9 @@ class ConversationListSelectHeader {
 
   ConversationListSelectHeader() {
     panel = new DivElement()
-      ..classes.add('conversation-list-select-header');
+      ..classes.add('conversation-list-select-header')
+      // TODO(mariana): Set visibility to hidden for now whilst the table selector isn't functional
+      ..style.visibility = 'hidden';
 
     panel.append(
       new SpanElement()


### PR DESCRIPTION
I think it would be a good idea to hide the conversation list selector until it's fully functional as it might confuse people trying to use it. I've added TODOs to the code to keep track of it.

cc @lukechurch 

Thanks!