### PR TITLE
populate list of conversation lists

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -266,6 +266,11 @@ void initUI() {
 
   platform.listenForConversations(
     (updatedConversations) {
+      if (updatedConversations.length != 1) {
+        log.verbose("loading/updating ${updatedConversations.length} conversations");
+      } else {
+        log.verbose("loading/updating conversation ${updatedConversations[0].docId}");
+      }
       var updatedIds = updatedConversations.map((t) => t.docId).toSet();
       conversations.removeWhere((conversation) => updatedIds.contains(conversation.docId));
       conversations.addAll(updatedConversations);

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -264,6 +264,10 @@ void initUI() {
     );
   }
 
+  platform.listenForConversationListShards((List<model.ConversationListShard> shards) {
+    view.conversationListSelectView.updateConversationLists(shards);
+  });
+
   platform.listenForConversations(
     (updatedConversations) {
       if (updatedConversations.length != 1) {

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -170,6 +170,7 @@ List<model.SystemMessage> systemMessages;
 
 UIActionObject actionObjectState = UIActionObject.conversation;
 
+StreamSubscription conversationListSubscription;
 Set<model.Conversation> conversations;
 Set<model.Conversation> filteredConversations;
 List<model.SuggestedReply> suggestedReplies;
@@ -284,7 +285,8 @@ void initUI() {
 }
 
 void conversationListSelected(String conversationListRoot) {
-  platform.listenForConversations(
+  conversationListSubscription?.cancel();
+  conversationListSubscription = platform.listenForConversations(
     (updatedConversations) {
       if (updatedConversations.length != 1) {
         log.verbose("loading/updating ${updatedConversations.length} conversations");

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -512,6 +512,8 @@ void command(UIAction action, Data data) {
     case UIAction.selectConversationList:
       ConversationListData conversationListData = data;
       view.conversationListPanelView.clearConversationList();
+      view.conversationPanelView.clear();
+      activeConversation = null;
       if (conversationListData.conversationListRoot == ConversationListData.NONE) {
         view.conversationListPanelView.showSelectConversationListMessage();
       } else {

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -109,6 +109,7 @@ class AfterDateFilterData extends Data {
 }
 
 class ConversationListData extends Data {
+  static const NONE = 'none';
   String conversationListRoot;
   ConversationListData(this.conversationListRoot);
 }
@@ -286,6 +287,8 @@ void initUI() {
 
 void conversationListSelected(String conversationListRoot) {
   conversationListSubscription?.cancel();
+  conversationListSubscription = null;
+  if (conversationListRoot == ConversationListData.NONE) return;
   conversationListSubscription = platform.listenForConversations(
     (updatedConversations) {
       if (updatedConversations.length != 1) {
@@ -508,6 +511,12 @@ void command(UIAction action, Data data) {
       break;
     case UIAction.selectConversationList:
       ConversationListData conversationListData = data;
+      view.conversationListPanelView.clearConversationList();
+      if (conversationListData.conversationListRoot == ConversationListData.NONE) {
+        view.conversationListPanelView.showSelectConversationListMessage();
+      } else {
+        view.conversationListPanelView.showLoadSpinner();
+      }
       conversationListSelected(conversationListData.conversationListRoot);
       break;
     case UIAction.selectConversation:

--- a/webapp/lib/controller_view_helper.dart
+++ b/webapp/lib/controller_view_helper.dart
@@ -16,6 +16,7 @@ enum TagReceiver {
 
 void _populateConversationListPanelView(Set<model.Conversation> conversations, bool updateList) {
   view.conversationListPanelView.hideLoadSpinner();
+  view.conversationListPanelView.hideSelectConversationListMessage();
   if (conversations.isEmpty || !updateList) {
     view.conversationListPanelView.clearConversationList();
   }

--- a/webapp/lib/model.dart
+++ b/webapp/lib/model.dart
@@ -6,9 +6,15 @@ export 'model.g.dart' hide
   MessageDirection_fromStringOverride,
   TagType_fromStringOverride;
 
-extension ConversationUtil on g.Conversation {
-  String get documentPath => "${g.Conversation.collectionName}/$docId";
+extension ConversationListShardUtil on g.ConversationListShard {
+  String get conversationListRoot => docId != null
+    ? "/${g.ConversationListShard.collectionName}/$docId/conversations"
+    : "/nook_conversations";
 
+  String get displayName => name ?? docId;
+}
+
+extension ConversationUtil on g.Conversation {
   String get shortDeidentifiedPhoneNumber => docId.split('uuid-')[1].split('-')[0];
 
   /// Return the most recent inbound message, or `null`

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -7,6 +7,33 @@ import 'logger.dart';
 
 Logger log = Logger('model.g.dart');
 
+class ConversationListShard {
+  static const collectionName = 'nook_conversation_shards';
+
+  String docId;
+  String name;
+
+  static ConversationListShard fromSnapshot(DocSnapshot doc, [ConversationListShard modelObj]) =>
+      fromData(doc.data, modelObj)..docId = doc.id;
+
+  static ConversationListShard fromData(data, [ConversationListShard modelObj]) {
+    if (data == null) return null;
+    return (modelObj ?? ConversationListShard())
+      ..name = String_fromData(data['name']);
+  }
+
+  static void listen(DocStorage docStorage, ConversationListShardCollectionListener listener,
+          {String collectionRoot = '/$collectionName'}) =>
+      listenForUpdates<ConversationListShard>(docStorage, listener, collectionRoot, ConversationListShard.fromSnapshot);
+
+  Map<String, dynamic> toData() {
+    return {
+      if (name != null) 'name': name,
+    };
+  }
+}
+typedef void ConversationListShardCollectionListener(List<ConversationListShard> changes);
+
 class Conversation {
   static const collectionName = 'nook_conversations';
 

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -22,7 +22,7 @@ class ConversationListShard {
       ..name = String_fromData(data['name']);
   }
 
-  static void listen(DocStorage docStorage, ConversationListShardCollectionListener listener,
+  static StreamSubscription listen(DocStorage docStorage, ConversationListShardCollectionListener listener,
           {String collectionRoot = '/$collectionName'}) =>
       listenForUpdates<ConversationListShard>(docStorage, listener, collectionRoot, ConversationListShard.fromSnapshot);
 
@@ -57,7 +57,7 @@ class Conversation {
       ..unread = bool_fromData(data['unread']) ?? true;
   }
 
-  static void listen(DocStorage docStorage, ConversationCollectionListener listener,
+  static StreamSubscription listen(DocStorage docStorage, ConversationCollectionListener listener,
           {String collectionRoot = '/$collectionName'}) =>
       listenForUpdates<Conversation>(docStorage, listener, collectionRoot, Conversation.fromSnapshot);
 
@@ -296,7 +296,7 @@ class SuggestedReply {
       ..category = String_fromData(data['category']);
   }
 
-  static void listen(DocStorage docStorage, SuggestedReplyCollectionListener listener,
+  static StreamSubscription listen(DocStorage docStorage, SuggestedReplyCollectionListener listener,
           {String collectionRoot = '/$collectionName'}) =>
       listenForUpdates<SuggestedReply>(docStorage, listener, collectionRoot, SuggestedReply.fromSnapshot);
 
@@ -414,7 +414,7 @@ class SystemMessage {
       ..expired = bool_fromData(data['expired']) ?? false;
   }
 
-  static void listen(DocStorage docStorage, SystemMessageCollectionListener listener,
+  static StreamSubscription listen(DocStorage docStorage, SystemMessageCollectionListener listener,
           {String collectionRoot = '/$collectionName'}) =>
       listenForUpdates<SystemMessage>(docStorage, listener, collectionRoot, SystemMessage.fromSnapshot);
 

--- a/webapp/lib/model.yaml
+++ b/webapp/lib/model.yaml
@@ -1,3 +1,7 @@
+ConversationListShard:
+  firebaseCollectionName: 'nook_conversation_shards'
+  name: 'string'
+
 Conversation:
   firebaseCollectionName: 'nook_conversations'
   demographicsInfo: 'map string'
@@ -37,6 +41,8 @@ SuggestedReply:
   text: 'string'
   translation: 'publishable string'
   shortcut: 'string'
+  seq_no: 'int seqNumber'
+  category: 'string'
 
 Tag:
   firebaseDocId: 'string tagId'

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -95,8 +95,8 @@ void listenForConversationListShards(ConversationListShardCollectionListener lis
   ConversationListShard.listen(_docStorage, listener);
 }
 
-void listenForConversations(ConversationCollectionListener listener, String conversationListRoot) {
-  Conversation.listen(_docStorage, listener, collectionRoot: conversationListRoot);
+StreamSubscription listenForConversations(ConversationCollectionListener listener, String conversationListRoot) {
+  return Conversation.listen(_docStorage, listener, collectionRoot: conversationListRoot);
 }
 
 void listenForConversationTags(TagCollectionListener listener) =>

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -95,8 +95,8 @@ void listenForConversationListShards(ConversationListShardCollectionListener lis
   ConversationListShard.listen(_docStorage, listener);
 }
 
-void listenForConversations(ConversationCollectionListener listener) {
-  Conversation.listen(_docStorage, listener, collectionRoot: "/${Conversation.collectionName}");
+void listenForConversations(ConversationCollectionListener listener, String conversationListRoot) {
+  Conversation.listen(_docStorage, listener, collectionRoot: conversationListRoot);
 }
 
 void listenForConversationTags(TagCollectionListener listener) =>

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -91,6 +91,10 @@ Future<void> sendMultiMessage(List<String> ids, String message) {
 void listenForSystemMessages(SystemMessageCollectionListener listener) =>
     SystemMessage.listen(_docStorage, listener);
 
+void listenForConversationListShards(ConversationListShardCollectionListener listener) {
+  ConversationListShard.listen(_docStorage, listener);
+}
+
 void listenForConversations(ConversationCollectionListener listener) {
   Conversation.listen(_docStorage, listener, collectionRoot: "/${Conversation.collectionName}");
 }

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -92,10 +92,7 @@ void listenForSystemMessages(SystemMessageCollectionListener listener) =>
     SystemMessage.listen(_docStorage, listener);
 
 void listenForConversations(ConversationCollectionListener listener) {
-  listenForUpdates<Conversation>(_docStorage, listener, "/${Conversation.collectionName}", (DocSnapshot conversation) {
-    log.verbose("_firestoreConversationToModelConversation: ${conversation.id}");
-    return Conversation.fromSnapshot(conversation);
-  });
+  Conversation.listen(_docStorage, listener, collectionRoot: "/${Conversation.collectionName}");
 }
 
 void listenForConversationTags(TagCollectionListener listener) =>

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -657,6 +657,7 @@ class ConversationListPanelView {
     conversationListPanel.append(_loadSpinner);
 
     _selectConversationListMessage = new DivElement()
+      ..classes.add('select-conversation-list-message')
       ..append(SpanElement()..text = "Select a conversation list above")
       ..hidden = true;
     conversationListPanel.append(_selectConversationListMessage);

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -45,8 +45,6 @@ void init() {
 }
 
 void initSignedInView() {
-  // TODO(mariana): Set visibility to hidden for now whilst the table selector isn't functional
-  conversationListSelectView.panel.style.visibility = 'hidden';
   clearMain();
 
   querySelector('main')
@@ -568,7 +566,6 @@ class ConversationListSelectHeader {
   ConversationListSelectHeader() {
     panel = new DivElement()
       ..classes.add('conversation-list-select-header')
-      // TODO(mariana): Set visibility to hidden for now whilst the table selector isn't functional
       ..style.visibility = 'hidden';
 
     panel.append(

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -594,12 +594,14 @@ class ConversationListSelectHeader {
       for (var shard in _shards) {
         _selectElement.add(OptionElement(data: shard.displayName, value: shard.conversationListRoot), null);
       }
+      conversationListSelectView.panel.style.visibility = 'visible';
     } else {
       // TODO If summary information is displayed, then update it here
     }
   }
 
-  void shardSelected(Event event) {
+  void shardSelected([Event event]) {
+    command(UIAction.selectConversationList, ConversationListData(_selectElement.value));
   }
 }
 

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -590,11 +590,18 @@ class ConversationListSelectHeader {
       } else {
         _shards.addAll(shards);
       }
-      _selectElement.add(OptionElement(data: 'Select the conversations to be displayed', value: null), null);
+      _selectElement.add(OptionElement(
+          data: 'Select the conversations to be displayed',
+          value: ConversationListData.NONE
+      ), null);
       for (var shard in _shards) {
-        _selectElement.add(OptionElement(data: shard.displayName, value: shard.conversationListRoot), null);
+        _selectElement.add(OptionElement(
+            data: shard.displayName,
+            value: shard.conversationListRoot
+        ), null);
       }
       conversationListSelectView.panel.style.visibility = 'visible';
+      shardSelected();
     } else {
       // TODO If summary information is displayed, then update it here
     }
@@ -612,6 +619,7 @@ class ConversationListPanelView {
   LazyListViewModel _conversationList;
   CheckboxInputElement _selectAllCheckbox;
   DivElement _loadSpinner;
+  DivElement _selectConversationListMessage;
 
   ConversationFilter conversationFilter;
 
@@ -647,6 +655,11 @@ class ConversationListPanelView {
     _loadSpinner = new DivElement()
       ..classes.add('load-spinner');
     conversationListPanel.append(_loadSpinner);
+
+    _selectConversationListMessage = new DivElement()
+      ..append(SpanElement()..text = "Select a conversation list above")
+      ..hidden = true;
+    conversationListPanel.append(_selectConversationListMessage);
 
     var conversationListElement = new DivElement()
       ..classes.add('conversation-list');
@@ -733,7 +746,17 @@ class ConversationListPanelView {
   }
 
   void showLoadSpinner() {
+    hideSelectConversationListMessage();
     _loadSpinner.hidden = false;
+  }
+
+  void hideSelectConversationListMessage() {
+    _selectConversationListMessage.hidden = true;
+  }
+
+  void showSelectConversationListMessage() {
+    hideLoadSpinner();
+    _selectConversationListMessage.hidden = false;
   }
 }
 

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -590,17 +590,21 @@ class ConversationListSelectHeader {
       } else {
         _shards.addAll(shards);
       }
-      _selectElement.add(OptionElement(
-          data: 'Select the conversations to be displayed',
-          value: ConversationListData.NONE
-      ), null);
+      if (_shards.length > 1) {
+        _selectElement.add(OptionElement(
+            data: 'Select the conversations to be displayed',
+            value: ConversationListData.NONE
+        ), null);
+      }
       for (var shard in _shards) {
         _selectElement.add(OptionElement(
             data: shard.displayName,
             value: shard.conversationListRoot
         ), null);
       }
-      conversationListSelectView.panel.style.visibility = 'visible';
+      if (_shards.length > 1) {
+        conversationListSelectView.panel.style.visibility = 'visible';
+      }
       shardSelected();
     } else {
       // TODO If summary information is displayed, then update it here

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -2,11 +2,11 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:intl/intl.dart';
-import 'package:nook/model.dart';
 
+import 'controller.dart';
 import 'dom_utils.dart';
 import 'logger.dart';
-import 'controller.dart';
+import 'model.dart';
 import 'lazy_list_view_model.dart';
 
 

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -562,6 +562,8 @@ class AfterDateFilterTagView extends FilterTagView {
 // A drop down to select which conversation list to display
 class ConversationListSelectHeader {
   DivElement panel;
+  SelectElement _selectElement;
+  List<ConversationListShard> _shards;
 
   ConversationListSelectHeader() {
     panel = new DivElement()
@@ -575,10 +577,32 @@ class ConversationListSelectHeader {
         ..text = 'Conversation List:');
 
     panel.append(
-      new SelectElement()
+      _selectElement = new SelectElement()
         ..classes.add('conversation-list-select')
-        // TODO dynamically populate this from firebase "tables/conversation-lists"
-        ..add(OptionElement(data: 'nook_conversations'), null));
+        ..add(OptionElement(data: '... loading conversation lists ...'), null)
+        ..onChange.listen(shardSelected));
+  }
+
+  void updateConversationLists(List<ConversationListShard> shards) {
+    // TODO Consider displaying summary information about each shard... e.g. # of unread conversations
+    if (_shards == null) {
+      _selectElement.options.first.remove();
+      _shards = [];
+      if (shards.isEmpty) {
+        _shards.add(ConversationListShard()..name = 'nook_conversations');
+      } else {
+        _shards.addAll(shards);
+      }
+      _selectElement.add(OptionElement(data: 'Select the conversations to be displayed', value: null), null);
+      for (var shard in _shards) {
+        _selectElement.add(OptionElement(data: shard.displayName, value: shard.conversationListRoot), null);
+      }
+    } else {
+      // TODO If summary information is displayed, then update it here
+    }
+  }
+
+  void shardSelected(Event event) {
   }
 }
 

--- a/webapp/web/styles.css
+++ b/webapp/web/styles.css
@@ -150,6 +150,12 @@ main {
     padding: 12px;
 }
 
+.select-conversation-list-message {
+    margin: auto;
+    padding-top: 50px;
+    font-weight: bold;
+}
+
 .conversation-list__item {
     display: flex;
     border-bottom: 1px solid lightgray;


### PR DESCRIPTION
This PR loads shards from `/nook_conversation_shards` and populates the conversation list selection dropdown with what is found. Another step towards https://github.com/larksystems/nook/issues/263

* When the user selects a list, then the conversation list is populated  from `/nook_conversation_shards/<shard-doc-id>/conversations`

* If exactly one shard is found, then the conversation list dropdown is not shown
  and the conversations are loaded from that one shard

* If no shards are found, then the conversation list dropdown is not shown 
  and conversations are loaded from `nook_conversations`

Here are some screenshot of what the user sees if more than one shard found...

-----------------------

<img width="470" alt="Screen Shot 2020-03-24 at 3 11 28 PM" src="https://user-images.githubusercontent.com/2891888/77468404-debaa880-6de3-11ea-85b5-e8c912773373.png">

-----------------------

<img width="475" alt="Screen Shot 2020-03-24 at 3 13 36 PM" src="https://user-images.githubusercontent.com/2891888/77468411-e24e2f80-6de3-11ea-94d2-8782ac3d2cec.png">

