### PR TITLE
Close braces for method which caused build failure

### DIFF
--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -772,6 +772,7 @@ class ConversationListPanelView {
   void showSelectConversationListMessage() {
     hideLoadSpinner();
     _selectConversationListMessage.hidden = false;
+  }
 
   void showConversationSelectCheckboxes(bool value) {
     _selectAllCheckbox.classes.toggle('hidden', !value);


### PR DESCRIPTION
Sorry - when I merged master into a previous PR using GitHub's web merge conflict tool, I accidentally missed adding a closing brace to a method, resulting in nook no longer building. This fixes it.

Merging immediately to avoid master being unable to build for long.

TBR @danrubel 