### PR TITLE
Listen to user configuration of UI features changes from firebase

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -311,15 +311,15 @@ void initUI() {
 
 /// Sets user customization flags from the data map
 /// If a flag is not set in the data map, it defaults to the existing values
-void applyConfiguration(model.UserConfiguration userConfiguration) {
-  view.replyPanelView.showShortcuts(userConfiguration.keyboardShortcutsEnabled ?? false);
-  view.tagPanelView.showShortcuts(userConfiguration.keyboardShortcutsEnabled ?? false);
+void applyConfiguration(model.UserConfiguration config) {
+  view.replyPanelView.showShortcuts(config.keyboardShortcutsEnabled ?? false);
+  view.tagPanelView.showShortcuts(config.keyboardShortcutsEnabled ?? false);
 
-  view.conversationPanelView.showCustomMessageBox(userConfiguration.sendCustomMessagesEnabled ?? false);
+  view.conversationPanelView.showCustomMessageBox(config.sendCustomMessagesEnabled ?? false);
 
-  view.conversationListPanelView.showConversationSelectCheckboxes(userConfiguration.sendMultiMessageEnabled ?? false);
+  view.conversationListPanelView.showConversationSelectCheckboxes(config.sendMultiMessageEnabled ?? false);
 
-  // TODO(mariana): Implement hide/show for the tag panel
+  view.showTagPanel(config.tagPanelVisibility ?? false);
 }
 
 void conversationListSelected(String conversationListRoot) {
@@ -619,7 +619,7 @@ void command(UIAction action, Data data) {
       break;
     case UIAction.keyPressed:
       // Keyboard shortcuts not enabled, skip processing the action.
-      if (!currentUserConfig.keyboardShortcutsEnabled) return;
+      if (!currentConfig.keyboardShortcutsEnabled) return;
 
       KeyPressData keyPressData = data;
       if (keyPressData.key == 'Enter') {
@@ -646,7 +646,8 @@ void command(UIAction action, Data data) {
         sendMultiReply(selectedReply.first, selectedConversations);
         return;
       }
-      // If the shortcut is for a tag, find it and tag it to the conversation/message
+      // If the shortcut is for a tag and tag panel is enabled, find it and tag it to the conversation/message
+      if (!currentConfig.tagPanelVisibility) return;
       switch (actionObjectState) {
         case UIActionObject.conversation:
           var selectedTag = _filterDemogsTagsIfNeeded(conversationTags).where((tag) => tag.shortcut == keyPressData.key);

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -196,11 +196,11 @@ bool hideDemogsTags;
 bool multiSelectMode;
 
 void init() async {
-  currentConfig = new model.UserConfiguration()
-  ..keyboardShortcutsEnabled = false
-  ..sendCustomMessagesEnabled = false
-  ..sendMultiMessageEnabled = false
-  ..tagPanelVisibility = false;
+  defaultUserConfig = currentUserConfig = currentConfig = new model.UserConfiguration()
+    ..keyboardShortcutsEnabled = false
+    ..sendCustomMessagesEnabled = false
+    ..sendMultiMessageEnabled = false
+    ..tagPanelVisibility = false;
   view.init();
   await platform.init();
 }
@@ -303,7 +303,7 @@ void initUI() {
     }
     defaultUserConfig = defaultConfig ?? defaultUserConfig;
     currentUserConfig = userConfig ?? currentUserConfig;
-    currentConfig = defaultUserConfig + currentUserConfig;
+    currentConfig = currentUserConfig.applyDefaults(defaultUserConfig);
     applyConfiguration(currentConfig);
   });
 }

--- a/webapp/lib/model.dart
+++ b/webapp/lib/model.dart
@@ -7,13 +7,13 @@ export 'model.g.dart' hide
   TagType_fromStringOverride;
 
 extension UserConfigurationUtil on g.UserConfiguration {
-  g.UserConfiguration operator +(g.UserConfiguration other) =>
+  g.UserConfiguration applyDefaults(g.UserConfiguration defaults) =>
     new g.UserConfiguration()
-      ..docId = other.docId
-      ..keyboardShortcutsEnabled = other.keyboardShortcutsEnabled ?? this.keyboardShortcutsEnabled
-      ..sendCustomMessagesEnabled = other.sendCustomMessagesEnabled ?? this.sendCustomMessagesEnabled
-      ..sendMultiMessageEnabled = other.sendMultiMessageEnabled ?? this.sendMultiMessageEnabled
-      ..tagPanelVisibility = other.tagPanelVisibility ?? this.tagPanelVisibility;
+      ..docId = null
+      ..keyboardShortcutsEnabled = this.keyboardShortcutsEnabled ?? defaults.keyboardShortcutsEnabled
+      ..sendCustomMessagesEnabled = this.sendCustomMessagesEnabled ?? defaults.sendCustomMessagesEnabled
+      ..sendMultiMessageEnabled = this.sendMultiMessageEnabled ?? defaults.sendMultiMessageEnabled
+      ..tagPanelVisibility = this.tagPanelVisibility ?? defaults.tagPanelVisibility;
 }
 
 extension ConversationListShardUtil on g.ConversationListShard {

--- a/webapp/lib/model.dart
+++ b/webapp/lib/model.dart
@@ -6,6 +6,16 @@ export 'model.g.dart' hide
   MessageDirection_fromStringOverride,
   TagType_fromStringOverride;
 
+extension UserConfigurationUtil on g.UserConfiguration {
+  g.UserConfiguration operator +(g.UserConfiguration other) =>
+    new g.UserConfiguration()
+      ..docId = other.docId
+      ..keyboardShortcutsEnabled = other.keyboardShortcutsEnabled ?? this.keyboardShortcutsEnabled
+      ..sendCustomMessagesEnabled = other.sendCustomMessagesEnabled ?? this.sendCustomMessagesEnabled
+      ..sendMultiMessageEnabled = other.sendMultiMessageEnabled ?? this.sendMultiMessageEnabled
+      ..tagPanelVisibility = other.tagPanelVisibility ?? this.tagPanelVisibility;
+}
+
 extension ConversationListShardUtil on g.ConversationListShard {
   String get conversationListRoot => docId != null
     ? "/${g.ConversationListShard.collectionName}/$docId/conversations"

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -427,6 +427,44 @@ class SystemMessage {
 }
 typedef void SystemMessageCollectionListener(List<SystemMessage> changes);
 
+class UserConfiguration {
+  static const collectionName = 'users';
+
+  String docId;
+  bool keyboardShortcutsEnabled;
+  bool sendCustomMessagesEnabled;
+  bool sendMultiMessageEnabled;
+  bool tagPanelVisibility;
+
+  String get userId => docId;
+
+  static UserConfiguration fromSnapshot(DocSnapshot doc, [UserConfiguration modelObj]) =>
+      fromData(doc.data, modelObj)..docId = doc.id;
+
+  static UserConfiguration fromData(data, [UserConfiguration modelObj]) {
+    if (data == null) return null;
+    return (modelObj ?? UserConfiguration())
+      ..keyboardShortcutsEnabled = bool_fromData(data['keyboard_shortcuts_enabled'])
+      ..sendCustomMessagesEnabled = bool_fromData(data['send_custom_messages_enabled'])
+      ..sendMultiMessageEnabled = bool_fromData(data['send_multi_message_enabled'])
+      ..tagPanelVisibility = bool_fromData(data['tag_panel_visibility']);
+  }
+
+  static StreamSubscription listen(DocStorage docStorage, UserConfigurationCollectionListener listener,
+          {String collectionRoot = '/$collectionName'}) =>
+      listenForUpdates<UserConfiguration>(docStorage, listener, collectionRoot, UserConfiguration.fromSnapshot);
+
+  Map<String, dynamic> toData() {
+    return {
+      if (keyboardShortcutsEnabled != null) 'keyboard_shortcuts_enabled': keyboardShortcutsEnabled,
+      if (sendCustomMessagesEnabled != null) 'send_custom_messages_enabled': sendCustomMessagesEnabled,
+      if (sendMultiMessageEnabled != null) 'send_multi_message_enabled': sendMultiMessageEnabled,
+      if (tagPanelVisibility != null) 'tag_panel_visibility': tagPanelVisibility,
+    };
+  }
+}
+typedef void UserConfigurationCollectionListener(List<UserConfiguration> changes);
+
 // ======================================================================
 // Core firebase/yaml utilities
 

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -472,7 +472,9 @@ class UserConfiguration {
     };
   }
 }
-typedef void UserConfigurationCollectionListener(List<UserConfiguration> changes);
+typedef void UserConfigurationCollectionListener(List<UserConfiguration> added,
+                                                 List<UserConfiguration> modified,
+                                                 List<UserConfiguration> removed);
 
 // ======================================================================
 // Core firebase/yaml utilities

--- a/webapp/lib/model.yaml
+++ b/webapp/lib/model.yaml
@@ -62,3 +62,11 @@ SystemMessage:
   firebaseDocId: 'string msgId'
   text: string
   expired: 'bool, false'
+
+UserConfiguration:
+  firebaseCollectionName: 'users'
+  firebaseDocId: 'string userId'
+  keyboard_shortcuts_enabled: 'bool keyboardShortcutsEnabled'
+  send_custom_messages_enabled: 'bool sendCustomMessagesEnabled'
+  send_multi_message_enabled: 'bool sendMultiMessageEnabled'
+  tag_panel_visibility: 'bool tagPanelVisibility'

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -73,6 +73,21 @@ void clearMain() {
   snackbarView.snackbarElement.remove();
 }
 
+void showTagPanel(bool show) {
+  if (show) {
+    tagPanelView.tagPanel.classes.toggle('hidden', false);
+    conversationListPanelView.conversationListPanel.classes.add('w-20');
+    conversationPanelView.conversationPanel.classes.add('w-40');
+    replyPanelView.replyPanel.classes.add('w-25');
+    tagPanelView.tagPanel.classes.add('w-15');
+    return;
+  }
+  tagPanelView.tagPanel.classes.toggle('hidden', true);
+  conversationListPanelView.conversationListPanel.classes.add('w-25');
+  conversationPanelView.conversationPanel.classes.add('w-45');
+  replyPanelView.replyPanel.classes.add('w-30');
+}
+
 bool sendingMultiMessagesUserConfirmation(int noMessages) {
   return window.confirm('Are you sure you want to send $noMessages SMS message${noMessages == 1 ? "" : "s" }?');
 }

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -171,7 +171,7 @@ class ConversationPanelView {
 
     _newMessageBox = new DivElement()
       ..classes.add('new-message-box');
-    if (!SEND_CUSTOM_MESSAGES_ENABLED) {
+    if (!currentConfig.sendCustomMessagesEnabled) {
       showCustomMessageBox(false);
     }
     conversationPanel.append(_newMessageBox);
@@ -651,7 +651,7 @@ class ConversationListPanelView {
       ..title = 'Select all conversations'
       ..checked = false
       ..onClick.listen((_) => _selectAllCheckbox.checked ? command(UIAction.enableMultiSelectMode, null) : command(UIAction.disableMultiSelectMode, null));
-    showConversationSelectCheckboxes(SEND_MULTI_MESSAGE_ENABLED);
+    showConversationSelectCheckboxes(currentConfig.sendMultiMessageEnabled);
     panelHeader.append(_selectAllCheckbox);
 
     _conversationPanelTitle = new DivElement()
@@ -861,7 +861,7 @@ class ConversationSummary with LazyListViewItem {
       ..style.visibility = 'hidden'
       ..onClick.listen((_) => _selectCheckbox.checked ? command(UIAction.selectConversation, new ConversationData(deidentifiedPhoneNumber))
                                                       : command(UIAction.deselectConversation, new ConversationData(deidentifiedPhoneNumber)));
-    showSelectCheckbox(SEND_MULTI_MESSAGE_ENABLED);
+    showSelectCheckbox(currentConfig.sendMultiMessageEnabled);
     conversationSummary.append(_selectCheckbox);
 
     var summaryMessage = new DivElement()
@@ -1126,7 +1126,7 @@ class ActionView {
     _shortcutElement = new DivElement()
       ..classes.add('action__shortcut')
       ..text = shortcut;
-    showShortcut(KEYBOARD_SHORTCUTS_ENABLED);
+    showShortcut(currentConfig.keyboardShortcutsEnabled);
     action.append(_shortcutElement);
 
     var textElement = new DivElement()
@@ -1152,7 +1152,7 @@ class ReplyActionView extends ActionView {
     _shortcutElement = new DivElement()
       ..classes.add('action__shortcut')
       ..text = shortcut;
-    showShortcut(KEYBOARD_SHORTCUTS_ENABLED);
+    showShortcut(currentConfig.keyboardShortcutsEnabled);
     action.append(_shortcutElement);
 
     var textTranslationWrapper = new DivElement()

--- a/webapp/web/index.html
+++ b/webapp/web/index.html
@@ -11,6 +11,7 @@
 
   <script defer src="main.dart.js"></script>
   <link rel="stylesheet" href="reset.css">
+  <link rel="stylesheet" href="utilities.css">
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="tags.css">
   <link rel="stylesheet" href="messages.css">

--- a/webapp/web/styles.css
+++ b/webapp/web/styles.css
@@ -40,20 +40,6 @@ main {
     flex-direction: column;
 }
 
-.conversation-panel {
-    width: 40%;
-}
-
-.conversation-list-panel,
-.reply-panel {
-    width: 22.5%;
-}
-
-.tag-panel {
-    width: 15%;
-}
-
-
 .conversation-list {
     flex: 1 1 auto;
     overflow: scroll;

--- a/webapp/web/utilities.css
+++ b/webapp/web/utilities.css
@@ -1,0 +1,23 @@
+
+/*** Widths */
+
+.w-05 { width: 05%; }
+.w-10 { width: 10%; }
+.w-15 { width: 15%; }
+.w-20 { width: 20%; }
+.w-25 { width: 25%; }
+.w-30 { width: 30%; }
+.w-35 { width: 35%; }
+.w-40 { width: 40%; }
+.w-45 { width: 45%; }
+.w-50 { width: 50%; }
+.w-55 { width: 55%; }
+.w-60 { width: 60%; }
+.w-65 { width: 65%; }
+.w-70 { width: 70%; }
+.w-75 { width: 75%; }
+.w-80 { width: 80%; }
+.w-85 { width: 85%; }
+.w-90 { width: 90%; }
+.w-95 { width: 95%; }
+.w-100 { width: 100%; }


### PR DESCRIPTION
Closes #286 

Follows up from #291 by replacing the single read of user configuration from firebase into a listener for any changes, and adding in the ability to hide/show the tag panel.

Thanks!