### PR TITLE
dynamically update conversation list names

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -536,6 +536,9 @@ void command(UIAction action, Data data) {
       break;
     case UIAction.selectConversationList:
       ConversationListData conversationListData = data;
+      conversations = emptyConversationsSet;
+      filteredConversations = emptyConversationsSet;
+      activeConversation = null;
       view.conversationListPanelView.clearConversationList();
       view.conversationPanelView.clear();
       activeConversation = null;

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -615,7 +615,32 @@ class ConversationListSelectHeader {
       }
       shardSelected();
     } else {
-      // TODO If summary information is displayed, then update it here
+      bool shardingHasChanged = false;
+      for (var newShard in shards) {
+        shardingHasChanged = true;
+        int optionIndex = _shards.length > 1 ? 1 : 0;
+        for (int shardIndex = 0; shardIndex < _shards.length; ++shardIndex) {
+          if (_shards[shardIndex].docId == newShard.docId) {
+            shardingHasChanged = false;
+            var oldOption = _selectElement.options[optionIndex];
+            var isSelected = oldOption.selected;
+            oldOption.replaceWith(OptionElement(
+                data: newShard.displayName,
+                value: newShard.conversationListRoot,
+                selected: isSelected
+            ));
+            _shards[shardIndex] = newShard;
+            break;
+          }
+          ++optionIndex;
+        }
+        if (shardingHasChanged) {
+          break;
+        }
+      }
+      if (shardingHasChanged) {
+        // TODO Prevent all user changes until page is refreshed and display a system message indicating as much
+      }
     }
   }
 


### PR DESCRIPTION
With this PR, if the name of a conversation list is changed in firebase (e.g. `Conversation list #1` changes to `Brian's conversations`), then the UI automatically reflects that change. In addition there is a fix to clear the list of conversations cached in the browser when a different conversation list is selected.