### PR TITLE
Add conversations to the list in one go rather than one by one

### DIFF
--- a/webapp/lib/lazy_list_view_model.dart
+++ b/webapp/lib/lazy_list_view_model.dart
@@ -44,7 +44,7 @@ class LazyListViewModel {
       position = 0;
     }
     _items.insert(position, item);
-    if (position < _listView.children.length) {
+    if (position < _listView.children.length - 1) {
       // Insert the item's element into the cached/visible DOM elements
       Node refChild = _listView.children[position];
       _listView.insertBefore(item.element, refChild);
@@ -52,6 +52,11 @@ class LazyListViewModel {
     } else {
       _updateCachedElements();
     }
+  }
+
+  void appendItems(Iterable<LazyListViewItem> items) {
+    _items.addAll(items);
+    _updateCachedElements();
   }
 
   void clearItems() {

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -730,28 +730,43 @@ class ConversationListPanelView {
       _conversationList.removeItem(summary);
       return true;
     });
+    List<ConversationSummary> conversationsToAdd = [];
     for (var conversation in conversations) {
-      addOrUpdateConversation(conversation);
+      ConversationSummary summary = _phoneToConversations[conversation.docId];
+      if (summary != null) {
+        updateConversationSummary(summary, conversation);
+        continue;
+      }
+      summary = new ConversationSummary(
+          conversation.docId,
+          conversation.messages.first.text,
+          conversation.unread);
+      conversationsToAdd.add(summary);
     }
+    _conversationList.appendItems(conversationsToAdd);
+    for (var conversation in conversationsToAdd) {
+      _phoneToConversations[conversation.deidentifiedPhoneNumber] = conversation;
+    }
+    _conversationPanelTitle.text = '${_phoneToConversations.length} conversations';
   }
 
   void addOrUpdateConversation(Conversation conversation) {
     ConversationSummary summary = _phoneToConversations[conversation.docId];
     if (summary != null) {
-      if (conversation.unread) {
-        summary._markUnread();
-      } else {
-        summary._markRead();
-      }
-    } else {
-      summary = new ConversationSummary(
-              conversation.docId,
-              conversation.messages.first.text,
-              conversation.unread);
-      _conversationList.addItem(summary, null);
-      _phoneToConversations[summary.deidentifiedPhoneNumber] = summary;
-      _conversationPanelTitle.text = '${_phoneToConversations.length} conversations';
+      updateConversationSummary(summary, conversation);
+      return;
     }
+    summary = new ConversationSummary(
+        conversation.docId,
+        conversation.messages.first.text,
+        conversation.unread);
+    _conversationList.addItem(summary, null);
+    _phoneToConversations[summary.deidentifiedPhoneNumber] = summary;
+    _conversationPanelTitle.text = '${_phoneToConversations.length} conversations';
+  }
+
+  void updateConversationSummary(ConversationSummary summary, Conversation conversation) {
+    conversation.unread ? summary._markUnread() : summary._markRead();
   }
 
   void selectConversation(String deidentifiedPhoneNumber) {


### PR DESCRIPTION
This reduces load time delays due to DOM render and reflow from about 7s to 250ms on my machine for 2k conversations.