### PR TITLE
Apply configs only on change and reset checkboxes when changing the config

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -370,6 +370,7 @@ void applyConfiguration(model.UserConfiguration newConfig) {
 }
 
 void conversationListSelected(String conversationListRoot) {
+  command(UIAction.deselectAllConversations, null);
   conversationListSubscription?.cancel();
   conversationListSubscription = null;
   if (conversationListRoot == ConversationListData.NONE) return;
@@ -459,7 +460,8 @@ void command(UIAction action, Data data) {
       action != UIAction.promptAfterDateFilter && action != UIAction.updateAfterDateFilter &&
       action != UIAction.signInButtonClicked && action != UIAction.signOutButtonClicked &&
       action != UIAction.userSignedIn && action != UIAction.userSignedOut &&
-      action != UIAction.updateSuggestedRepliesCategory && action != UIAction.hideAgeTags) {
+      action != UIAction.updateSuggestedRepliesCategory && action != UIAction.hideAgeTags &&
+      action != UIAction.selectAllConversations && action != UIAction.deselectAllConversations) {
     return;
   }
 

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -335,8 +335,8 @@ void initUI() {
       }
       defaultUserConfig = defaultConfig ?? defaultUserConfig;
       currentUserConfig = userConfig ?? currentUserConfig;
-      currentConfig = currentUserConfig.applyDefaults(defaultUserConfig);
-      applyConfiguration(currentConfig);
+      var newConfig = currentUserConfig.applyDefaults(defaultUserConfig);
+      applyConfiguration(newConfig);
     }
   );
 }
@@ -344,15 +344,26 @@ void initUI() {
 
 /// Sets user customization flags from the data map
 /// If a flag is not set in the data map, it defaults to the existing values
-void applyConfiguration(model.UserConfiguration config) {
-  view.replyPanelView.showShortcuts(config.keyboardShortcutsEnabled ?? false);
-  view.tagPanelView.showShortcuts(config.keyboardShortcutsEnabled ?? false);
+void applyConfiguration(model.UserConfiguration newConfig) {
+  if (currentConfig.keyboardShortcutsEnabled != newConfig.keyboardShortcutsEnabled) {
+    view.replyPanelView.showShortcuts(newConfig.keyboardShortcutsEnabled ?? false);
+    view.tagPanelView.showShortcuts(newConfig.keyboardShortcutsEnabled ?? false);
+  }
 
-  view.conversationPanelView.showCustomMessageBox(config.sendCustomMessagesEnabled ?? false);
+  if (currentConfig.sendCustomMessagesEnabled != newConfig.sendCustomMessagesEnabled) {
+    view.conversationPanelView.showCustomMessageBox(newConfig.sendCustomMessagesEnabled ?? false);
+  }
 
-  view.conversationListPanelView.showConversationSelectCheckboxes(config.sendMultiMessageEnabled ?? false);
+  if (currentConfig.sendMultiMessageEnabled != newConfig.sendMultiMessageEnabled) {
+    view.conversationListPanelView.showConversationSelectCheckboxes(newConfig.sendMultiMessageEnabled ?? false);
+    command(UIAction.disableMultiSelectMode, null);
+  }
 
-  view.showTagPanel(config.tagPanelVisibility ?? false);
+  if (currentConfig.tagPanelVisibility != newConfig.tagPanelVisibility) {
+    view.showTagPanel(newConfig.tagPanelVisibility ?? false);
+  }
+
+  currentConfig = newConfig;
 }
 
 void conversationListSelected(String conversationListRoot) {
@@ -743,6 +754,7 @@ void command(UIAction action, Data data) {
       multiSelectMode = true;
       break;
     case UIAction.disableMultiSelectMode:
+      view.conversationListPanelView.uncheckSelectAllCheckbox();
       view.conversationListPanelView.uncheckAllConversations();
       view.conversationListPanelView.hideCheckboxes();
       selectedConversations.clear();

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -359,7 +359,6 @@ void applyConfiguration(model.UserConfiguration newConfig) {
       view.conversationListPanelView.hideCheckboxes();
       command(UIAction.deselectAllConversations, null);
     }
-
   }
 
   if (currentConfig.tagPanelVisibility != newConfig.tagPanelVisibility) {

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -810,6 +810,8 @@ class ConversationListPanelView {
     _markUnread.multiSelectMode(false);
   }
 
+  void uncheckSelectAllCheckbox() => _selectAllCheckbox.checked = false;
+
   void hideLoadSpinner() {
     _loadSpinner.hidden = true;
   }
@@ -982,7 +984,7 @@ class ConversationSummary with LazyListViewItem {
   }
 
   void showSelectCheckbox(bool value) {
-    _selectCheckbox.classes.toggle('hidden', !value);
+    if (_selectCheckbox != null) _selectCheckbox.classes.toggle('hidden', !value);
   }
 }
 


### PR DESCRIPTION
This fixes an issue when, if multiple conversations were selected and the `send_multi_message_enabled` was set to false afterwards, the multiple messages were still selected in the background, resulting in multiple messages still being sent.

Also changes `applyConfiguration` to update only the features for which the configuration has changed.