### PR TITLE
Remove logging the project for the theme analytics

### DIFF
--- a/tool/compute_tag_analytics.py
+++ b/tool/compute_tag_analytics.py
@@ -115,8 +115,6 @@ def compute_daily_tag_distribution(nook_conversations, ignore_stop=False):
                     date_daily_metrics_group[sub_metric] += 1
             daily_metrics[date] = date_daily_metrics
 
-    daily_metrics["project"] = KK_PROJECT
-
     time_end = time.perf_counter_ns()
 
     ms_elapsed = (time_end - time_start) / (1000 * 1000)


### PR DESCRIPTION
The current data setup for theme analytics reporting is different to those for nook_watcher and would likely require some firebase datastore layout changes. Best to just remove it for now to allow the rest of the analytics to run.