### PR TITLE
Update checkboxes logic

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -46,8 +46,8 @@ enum UIAction {
   keyPressed,
   addNewSuggestedReply,
   addNewTag,
-  enableMultiSelectMode,
-  disableMultiSelectMode,
+  selectAllConversations,
+  deselectAllConversations,
   updateSystemMessages,
   updateSuggestedRepliesCategory,
   hideAgeTags
@@ -193,7 +193,6 @@ model.UserConfiguration currentUserConfig;
 model.UserConfiguration currentConfig;
 
 bool hideDemogsTags;
-bool multiSelectMode;
 
 void init() async {
   defaultUserConfig = currentConfig = baseUserConfiguration;
@@ -210,7 +209,6 @@ void initUI() {
   conversationTags = [];
   messageTags = [];
   selectedConversations = [];
-  multiSelectMode = false;
   activeConversation = null;
   selectedSuggestedRepliesCategory = '';
   hideDemogsTags = true;
@@ -350,7 +348,11 @@ void applyConfiguration(model.UserConfiguration config) {
 
   view.conversationPanelView.showCustomMessageBox(config.sendCustomMessagesEnabled ?? false);
 
-  view.conversationListPanelView.showConversationSelectCheckboxes(config.sendMultiMessageEnabled ?? false);
+  if (config.sendMultiMessageEnabled) {
+    view.conversationListPanelView.showCheckboxes();
+  } else {
+    view.conversationListPanelView.hideCheckboxes();
+  }
 
   view.showTagPanel(config.tagPanelVisibility ?? false);
 }
@@ -395,6 +397,11 @@ void conversationListSelected(String conversationListRoot) {
       _populateSelectedFilterTags(filterTags);
 
       activeConversation = updateViewForConversations(filteredConversations, updateList: true);
+      if (currentConfig.sendMultiMessageEnabled) {
+        view.conversationListPanelView.showCheckboxes();
+        selectedConversations = selectedConversations.toSet().intersection(filteredConversations.toSet()).toList();
+        selectedConversations.forEach((conversation) => view.conversationListPanelView.checkConversation(conversation.docId));
+      }
       if (activeConversation == null) return;
 
       // Update the active conversation view as needed
@@ -455,7 +462,7 @@ void command(UIAction action, Data data) {
           ..translation = '';
         selectedReply = translationReply;
       }
-      if (!multiSelectMode) {
+      if (!currentConfig.sendMultiMessageEnabled || selectedConversations.isEmpty) {
         sendReply(selectedReply, activeConversation);
         return;
       }
@@ -470,14 +477,6 @@ void command(UIAction action, Data data) {
       oneoffReply
         ..text = replyData.replyText
         ..translation = '';
-      if (multiSelectMode) {
-        if (!view.sendingManualMultiMessageUserConfirmation(oneoffReply.text, selectedConversations.length)) {
-          return;
-        }
-        sendMultiReply(oneoffReply, selectedConversations);
-        view.conversationPanelView.clearNewMessageBox();
-        return;
-      }
       if (!view.sendingManualMessageUserConfirmation(oneoffReply.text)) {
         return;
       }
@@ -489,7 +488,7 @@ void command(UIAction action, Data data) {
       switch (actionObjectState) {
         case UIActionObject.conversation:
           model.Tag tag = conversationTags.singleWhere((tag) => tag.tagId == tagData.tagId);
-          if (!multiSelectMode) {
+          if (!currentConfig.sendMultiMessageEnabled || selectedConversations.isEmpty) {
             setConversationTag(tag, activeConversation);
             return;
           }
@@ -587,19 +586,19 @@ void command(UIAction action, Data data) {
       platform.updateUnread([activeConversation], false).catchError(showAndLogError);
       break;
     case UIAction.markConversationUnread:
-      if (multiSelectMode) {
-        var markedConversations = <model.Conversation>[];
-        for (var conversation in selectedConversations) {
-          if (!conversation.unread) {
-            markedConversations.add(conversation);
-            view.conversationListPanelView.markConversationUnread(conversation.docId);
-          }
-        }
-        platform.updateUnread(markedConversations, true).catchError(showAndLogError);
-      } else {
+      if (!currentConfig.sendMultiMessageEnabled || selectedConversations.isEmpty) {
         view.conversationListPanelView.markConversationUnread(activeConversation.docId);
         platform.updateUnread([activeConversation], true).catchError(showAndLogError);
+        return;
       }
+      var markedConversations = <model.Conversation>[];
+      for (var conversation in selectedConversations) {
+        if (!conversation.unread) {
+          markedConversations.add(conversation);
+          view.conversationListPanelView.markConversationUnread(conversation.docId);
+        }
+      }
+      platform.updateUnread(markedConversations, true).catchError(showAndLogError);
       break;
     case UIAction.showConversation:
       ConversationData conversationData = data;
@@ -610,6 +609,7 @@ void command(UIAction action, Data data) {
       ConversationListData conversationListData = data;
       conversations = emptyConversationsSet;
       filteredConversations = emptyConversationsSet;
+      selectedConversations.clear();
       activeConversation = null;
       view.conversationListPanelView.clearConversationList();
       view.conversationPanelView.clear();
@@ -699,7 +699,7 @@ void command(UIAction action, Data data) {
       var selectedReply = suggestedRepliesByCategory[selectedSuggestedRepliesCategory].where((reply) => reply.shortcut == keyPressData.key);
       if (selectedReply.isNotEmpty) {
         assert (selectedReply.length == 1);
-        if (!multiSelectMode) {
+        if (!currentConfig.sendMultiMessageEnabled || selectedConversations.isEmpty) {
           sendReply(selectedReply.first, activeConversation);
           return;
         }
@@ -717,7 +717,7 @@ void command(UIAction action, Data data) {
           if (selectedTag.isEmpty) break;
           assert (selectedTag.length == 1);
           setConversationTag(selectedTag.first, activeConversation);
-          if (!multiSelectMode) {
+          if (!currentConfig.sendMultiMessageEnabled || selectedConversations.isEmpty) {
             setConversationTag(selectedTag.first, activeConversation);
             return;
           }
@@ -743,18 +743,14 @@ void command(UIAction action, Data data) {
       AddTagData tagData = data;
       // TODO: call platform
       break;
-    case UIAction.enableMultiSelectMode:
-      view.conversationListPanelView.showCheckboxes();
+    case UIAction.selectAllConversations:
       view.conversationListPanelView.checkAllConversations();
       selectedConversations.clear();
       selectedConversations.addAll(filteredConversations);
-      multiSelectMode = true;
       break;
-    case UIAction.disableMultiSelectMode:
+    case UIAction.deselectAllConversations:
       view.conversationListPanelView.uncheckAllConversations();
-      view.conversationListPanelView.hideCheckboxes();
       selectedConversations.clear();
-      multiSelectMode = false;
       break;
     case UIAction.updateSystemMessages:
       SystemMessagesData msgData = data;
@@ -793,7 +789,7 @@ void command(UIAction action, Data data) {
 void updateFilteredConversationList() {
   filteredConversations = filterConversationsByTags(conversations, filterTags, afterDateFilter);
   activeConversation = updateViewForConversations(filteredConversations);
-  if (multiSelectMode) {
+  if (currentConfig.sendMultiMessageEnabled) {
     view.conversationListPanelView.showCheckboxes();
     selectedConversations = selectedConversations.toSet().intersection(filteredConversations.toSet()).toList();
     selectedConversations.forEach((conversation) => view.conversationListPanelView.checkConversation(conversation.docId));

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -694,8 +694,7 @@ class ConversationListPanelView {
       ..classes.add('conversation-list-header__checkbox')
       ..title = 'Select all conversations'
       ..checked = false
-      ..onClick.listen((_) => _selectAllCheckbox.checked ? command(UIAction.enableMultiSelectMode, null) : command(UIAction.disableMultiSelectMode, null));
-    showConversationSelectCheckboxes(currentConfig.sendMultiMessageEnabled);
+      ..onClick.listen((_) => _selectAllCheckbox.checked ? command(UIAction.selectAllConversations, null) : command(UIAction.deselectAllConversations, null));
     panelHeader.append(_selectAllCheckbox);
 
     _conversationPanelTitle = new DivElement()
@@ -726,6 +725,8 @@ class ConversationListPanelView {
 
     conversationFilter = new ConversationFilter();
     conversationListPanel.append(conversationFilter.conversationFilter);
+
+    currentConfig.sendMultiMessageEnabled ? showCheckboxes() : hideCheckboxes();
   }
 
   void updateConversationList(Set<Conversation> conversations) {
@@ -806,10 +807,12 @@ class ConversationListPanelView {
   void checkAllConversations() => _phoneToConversations.forEach((_, conversation) => conversation._check());
   void uncheckAllConversations() => _phoneToConversations.forEach((_, conversation) => conversation._uncheck());
   void showCheckboxes() {
+    _selectAllCheckbox.hidden = false;
     _phoneToConversations.forEach((_, conversation) => conversation._showCheckbox());
     _markUnread.multiSelectMode(true);
   }
   void hideCheckboxes() {
+    _selectAllCheckbox.hidden = true;
     _phoneToConversations.forEach((_, conversation) => conversation._hideCheckbox());
     _markUnread.multiSelectMode(false);
   }
@@ -831,13 +834,6 @@ class ConversationListPanelView {
   void showSelectConversationListMessage() {
     hideLoadSpinner();
     _selectConversationListMessage.hidden = false;
-  }
-
-  void showConversationSelectCheckboxes(bool value) {
-    _selectAllCheckbox.classes.toggle('hidden', !value);
-    for (var conversation in _phoneToConversations.values) {
-      conversation.showSelectCheckbox(value);
-    }
   }
 }
 
@@ -906,6 +902,7 @@ class ConversationSummary with LazyListViewItem {
   bool _unread;
   bool _checked = false;
   bool _selected = false;
+  bool _checkboxVisible = false;
 
   ConversationSummary(this.deidentifiedPhoneNumber, this._text, this._unread);
 
@@ -917,10 +914,10 @@ class ConversationSummary with LazyListViewItem {
       ..classes.add('conversation-selector')
       ..title = 'Select conversation'
       ..checked = _checked
-      ..style.visibility = 'hidden'
+      ..hidden = _checkboxVisible
       ..onClick.listen((_) => _selectCheckbox.checked ? command(UIAction.selectConversation, new ConversationData(deidentifiedPhoneNumber))
                                                       : command(UIAction.deselectConversation, new ConversationData(deidentifiedPhoneNumber)));
-    showSelectCheckbox(currentConfig.sendMultiMessageEnabled);
+    currentConfig.sendMultiMessageEnabled ? _showCheckbox() : _hideCheckbox();
     conversationSummary.append(_selectCheckbox);
 
     var summaryMessage = new DivElement()
@@ -979,14 +976,12 @@ class ConversationSummary with LazyListViewItem {
     if (_selectCheckbox != null) _selectCheckbox.checked = false;
   }
   void _showCheckbox() {
-    if (_selectCheckbox != null) _selectCheckbox.style.visibility = 'visible';
+    _checkboxVisible = true;
+    if (_selectCheckbox != null) _selectCheckbox.hidden = false;
   }
   void _hideCheckbox() {
-    if (_selectCheckbox != null) _selectCheckbox.style.visibility = 'hidden';
-  }
-
-  void showSelectCheckbox(bool value) {
-    if (_selectCheckbox != null) _selectCheckbox.classes.toggle('hidden', !value);
+    _checkboxVisible = false;
+    if (_selectCheckbox != null) _selectCheckbox.hidden = true;
   }
 }
 

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -902,7 +902,7 @@ class ConversationSummary with LazyListViewItem {
   bool _unread;
   bool _checked = false;
   bool _selected = false;
-  bool _checkboxVisible = false;
+  bool _checkboxHidden = true;
 
   ConversationSummary(this.deidentifiedPhoneNumber, this._text, this._unread);
 
@@ -914,7 +914,7 @@ class ConversationSummary with LazyListViewItem {
       ..classes.add('conversation-selector')
       ..title = 'Select conversation'
       ..checked = _checked
-      ..hidden = _checkboxVisible
+      ..hidden = _checkboxHidden
       ..onClick.listen((_) => _selectCheckbox.checked ? command(UIAction.selectConversation, new ConversationData(deidentifiedPhoneNumber))
                                                       : command(UIAction.deselectConversation, new ConversationData(deidentifiedPhoneNumber)));
     currentConfig.sendMultiMessageEnabled ? _showCheckbox() : _hideCheckbox();
@@ -976,11 +976,11 @@ class ConversationSummary with LazyListViewItem {
     if (_selectCheckbox != null) _selectCheckbox.checked = false;
   }
   void _showCheckbox() {
-    _checkboxVisible = true;
+    _checkboxHidden = false;
     if (_selectCheckbox != null) _selectCheckbox.hidden = false;
   }
   void _hideCheckbox() {
-    _checkboxVisible = false;
+    _checkboxHidden = true;
     if (_selectCheckbox != null) _selectCheckbox.hidden = true;
   }
 }


### PR DESCRIPTION
With this PR, the conversation list checkboxes will be shown all the time if the `send_multi_message_enabled` flag is set to `true`, as opposed to only when the select all checkbox is ticked. This is to support selecting messages one by one, starting from no selected messages.