### PR TITLE
Add uptime monitoring every min and every 5 secs if minute ping fails

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -50,7 +50,8 @@ enum UIAction {
   deselectAllConversations,
   updateSystemMessages,
   updateSuggestedRepliesCategory,
-  hideAgeTags
+  hideAgeTags,
+  showSnackbar
 }
 
 class Data {}
@@ -226,6 +227,15 @@ class ToggleData extends Data {
 
   @override
   String toString() => 'ToggleData: {toggleValue: $toggleValue}';
+}
+
+class SnackbarData extends Data {
+  String text;
+  SnackbarNotificationType type;
+  SnackbarData(text, type);
+
+  @override
+  String toString() => 'SnackbarData: {text: $text, type: $type}';
 }
 
 List<model.SystemMessage> systemMessages;
@@ -529,7 +539,8 @@ void command(UIAction action, Data data) {
       action != UIAction.signInButtonClicked && action != UIAction.signOutButtonClicked &&
       action != UIAction.userSignedIn && action != UIAction.userSignedOut &&
       action != UIAction.updateSuggestedRepliesCategory && action != UIAction.hideAgeTags &&
-      action != UIAction.selectAllConversations && action != UIAction.deselectAllConversations) {
+      action != UIAction.selectAllConversations && action != UIAction.deselectAllConversations &&
+      action != UIAction.showSnackbar) {
     return;
   }
 
@@ -876,7 +887,11 @@ void command(UIAction action, Data data) {
       // The filter tags menu always shows conversations tags, even when a message is selected
       _populateFilterTagsMenu(filteredConversationTags);
       break;
-    default:
+
+    case UIAction.showSnackbar:
+      SnackbarData snackbarData = data;
+      view.snackbarView.showSnackbar(snackbarData.text, snackbarData.type);
+      break;
   }
 }
 
@@ -969,9 +984,10 @@ void sendReply(model.SuggestedReply reply, model.Conversation conversation) {
       incoming: false);
   view.conversationPanelView.addMessage(newMessageView);
   log.verbose('Sending reply "${reply.text}" to conversation ${conversation.docId}');
-  platform.sendMessage(conversation.docId, reply.text, onError: (_) {
+  platform.sendMessage(conversation.docId, reply.text, onError: (error) {
     log.error('Reply "${reply.text}" failed to be sent to conversation ${conversation.docId}');
-    view.snackbarView.showSnackbar('Send Reply Failed', view.SnackbarNotificationType.error);
+    log.error('Error: ${error}');
+    command(UIAction.showSnackbar, new SnackbarData('Send Reply Failed', SnackbarNotificationType.error));
     newMessage.status = model.MessageStatus.failed;
     newMessageView.setStatus(newMessage.status);
   });
@@ -1001,9 +1017,10 @@ void sendMultiReply(model.SuggestedReply reply, List<model.Conversation> convers
     view.conversationPanelView.addMessage(newMessageView);
   }
   log.verbose('Sending reply "${reply.text}" to conversations ${conversationIds}');
-  platform.sendMultiMessage(conversationIds, newMessage.text, onError: (_) {
+  platform.sendMultiMessage(conversationIds, newMessage.text, onError: (error) {
     log.error('Reply "${reply.text}" failed to be sent to conversations ${conversationIds}');
-    view.snackbarView.showSnackbar('Send Multi Reply Failed', view.SnackbarNotificationType.error);
+    log.error('Error: ${error}');
+    command(UIAction.showSnackbar, new SnackbarData('Send Multi Reply Failed', SnackbarNotificationType.error));
     newMessage.status = model.MessageStatus.failed;
     newMessageView?.setStatus(newMessage.status);
   });
@@ -1145,5 +1162,5 @@ void showAndLogError(error, trace) {
   } else {
     errMsg = "$error";
   }
-  view.snackbarView.showSnackbar(errMsg, view.SnackbarNotificationType.error);
+  command(UIAction.showSnackbar, new SnackbarData(errMsg, SnackbarNotificationType.error));
 }

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -525,6 +525,8 @@ model.Conversation nextElement(Iterable<model.Conversation> conversations, model
   return conversations.first;
 }
 
+DateTime lastUserActivity = new DateTime.now();
+
 void command(UIAction action, Data data) {
   log.verbose('Executing UI command: $actionObjectState - $action - $data');
   log.verbose('Active conversation: ${activeConversation?.docId}');
@@ -542,6 +544,18 @@ void command(UIAction action, Data data) {
       action != UIAction.selectAllConversations && action != UIAction.deselectAllConversations &&
       action != UIAction.showSnackbar) {
     return;
+  }
+
+  switch (action) {
+    case UIAction.userSignedIn:
+    case UIAction.userSignedOut:
+    case UIAction.updateSystemMessages:
+    case UIAction.showSnackbar:
+      // These are not user actions, skip
+      break;
+    default:
+      lastUserActivity = new DateTime.now();
+      break;
   }
 
   switch (action) {

--- a/webapp/lib/controller_view_helper.dart
+++ b/webapp/lib/controller_view_helper.dart
@@ -12,6 +12,13 @@ enum TagReceiver {
   Message
 }
 
+enum SnackbarNotificationType {
+  info,
+  success,
+  warning,
+  error
+}
+
 // Functions to populate the views with model objects.
 
 void _populateConversationListPanelView(Set<model.Conversation> conversations, bool updateList) {

--- a/webapp/lib/logger.dart
+++ b/webapp/lib/logger.dart
@@ -25,6 +25,15 @@ class Logger {
     }
   }
 
+  void success(String s) {
+    switch (logLevel) {
+      case LogLevel.ERROR:
+        return;
+      default:
+        _log(s);
+    }
+  }
+
   void debug(String s) {
     switch (logLevel) {
       case LogLevel.WARNING:

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -66,6 +66,8 @@ void initUptimeMonitoring() {
       };
       _uptimePubSubInstance.publish(platform_constants.statuszTopic, payload).then(
         (_) {
+          log.success('Uptime ping ${t.tick}.${tt.tick} successful');
+
           // Add success to the three pings queue
           lastThreePingsQueue.add(true);
           lastThreePingsQueue.removeAt(0);
@@ -116,6 +118,8 @@ void initUptimeMonitoring() {
     };
     _uptimePubSubInstance.publish(platform_constants.statuszTopic, payload).then(
       (_) {
+        log.success('Uptime ping ${t.tick} successful');
+
         // Cancel the previous 5 sec timer if it's still going.
         fiveSecTimer?.cancel();
 

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -49,7 +49,6 @@ init() async {
 }
 
 void initUptimeMonitoring() {
-  print('starting uptime monitoring...');
   const fiveSeconds = const Duration(seconds: 5);
   const oneMinute = const Duration(minutes: 1);
 
@@ -61,7 +60,11 @@ void initUptimeMonitoring() {
 
   Timer Function(Timer) newFiveSecTimer = (Timer t) {
     return new Timer.periodic(fiveSeconds, (Timer tt) {
-      _uptimePubSubInstance.publish(platform_constants.statuszTopic, {'ping': '${t.tick}.${tt.tick}'}).then(
+      Map payload = {
+        'ping': '${t.tick}.${tt.tick}',
+        'lastUserActivity': controller.lastUserActivity.toIso8601String()
+      };
+      _uptimePubSubInstance.publish(platform_constants.statuszTopic, payload).then(
         (_) {
           // Add success to the three pings queue
           lastThreePingsQueue.add(true);
@@ -107,7 +110,11 @@ void initUptimeMonitoring() {
   };
 
   new Timer.periodic(oneMinute, (Timer t) {
-    _uptimePubSubInstance.publish(platform_constants.statuszTopic, {'ping': '${t.tick}'}).then(
+    Map payload = {
+      'ping': '${t.tick}',
+      'lastUserActivity': controller.lastUserActivity.toIso8601String()
+    };
+    _uptimePubSubInstance.publish(platform_constants.statuszTopic, payload).then(
       (_) {
         // Cancel the previous 5 sec timer if it's still going.
         fiveSecTimer?.cancel();

--- a/webapp/lib/platform_constants.dart
+++ b/webapp/lib/platform_constants.dart
@@ -21,4 +21,6 @@ String get storageBucket => _constants['storageBucket'];
 String get messagingSenderId => _constants['messagingSenderId'];
 String get logUrl => _constants['logUrl'];
 String get publishUrl => _constants['publishUrl'];
+String get statuszUrl => _constants['statuszUrl'];
 String get smsTopic => projectId + '-sms-channel-topic';
+String get statuszTopic => projectId + '-statusz-topic';

--- a/webapp/lib/pubsub.dart
+++ b/webapp/lib/pubsub.dart
@@ -20,8 +20,8 @@ class PubSubClient extends DocPubSubUpdate {
 
   PubSubClient(this.publishUrl, this.user);
 
-  /// Publish the specified exception.
-  /// Callers should catch and handle IOException.
+  /// Publish the specified [payload] to the [topic].
+  /// Callers should catch and handle PubSubException.
   Future<void> publish(String topic, Map payload) async {
     // a simplistic way to correlate publish log entries
     int publishId = _publishCount++;
@@ -89,7 +89,7 @@ class PubSubException implements Exception {
   final String message;
 
   static fromResponse(Response response) =>
-      PubSubException('[${response.statusCode}] ${response.reasonPhrase}');
+      PubSubException('[${response.statusCode}] ${response.reasonPhrase}, response.headers: ${response.headers}');
 
   PubSubException(this.message);
 

--- a/webapp/lib/pubsub.dart
+++ b/webapp/lib/pubsub.dart
@@ -21,7 +21,7 @@ class PubSubClient extends DocPubSubUpdate {
   PubSubClient(this.publishUrl, this.user);
 
   /// Publish the specified [payload] to the [topic].
-  /// Callers should catch and handle PubSubException.
+  /// Callers should catch and handle HTTP exceptions (e.g. PubSubException, ClientException).
   Future<void> publish(String topic, Map payload) async {
     // a simplistic way to correlate publish log entries
     int publishId = _publishCount++;

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -325,7 +325,7 @@ class AfterDateFilterView {
     try {
       dateTime = parseAfterDateFilterText(_textArea.value);
     } on FormatException catch (e) {
-      snackbarView.showSnackbar("Invalid date/time format: ${e.message}", SnackbarNotificationType.error);
+      command(UIAction.showSnackbar, new SnackbarData("Invalid date/time format: ${e.message}", SnackbarNotificationType.error));
       return;
     }
     command(UIAction.updateAfterDateFilter, new AfterDateFilterData(AFTER_DATE_TAG_ID, dateTime));
@@ -1508,13 +1508,6 @@ class UrlView {
     }
     return false;
   }
-}
-
-enum SnackbarNotificationType {
-  info,
-  success,
-  warning,
-  error
 }
 
 class SnackbarView {


### PR DESCRIPTION
This also adds a snackbar/toast that could be triggered from the platform. I initially did this so I can trigger the snackbar to show failures, but since it's so intrusive, I ended up using the banner notification instead.