### PR TITLE
Compare project ids & fix relative path issue

### DIFF
--- a/tool/deploy_webapp.sh
+++ b/tool/deploy_webapp.sh
@@ -5,36 +5,69 @@ if [ $# -ne 2 ]; then
     exit 1
 fi
 
-########## cd to the nook project directory and get the absolute path
-
-cd "$(dirname "$0")"/..
-PROJDIR="$(pwd)"
+WORK_DIR="$(pwd)"
 
 ########## validate argument(s)
 
 FIREBASE_CONSTANTS="$1"
 if [ ! -f "$FIREBASE_CONSTANTS" ]; then
   echo "could not find FIREBASE_CONSTANTS: $FIREBASE_CONSTANTS"
-  echo "  in: $(pwd)"
   exit 1
 fi
 
-CRYPTO_TOKEN_FILE="$2"
-if [ ! -f "$CRYPTO_TOKEN_FILE" ]; then
-  echo "could not find CRYPTO_TOKEN_FILE: $CRYPTO_TOKEN_FILE"
-  echo "  in: $(pwd)"
+cd "$(dirname "$FIREBASE_CONSTANTS")"
+FIREBASE_CONSTANTS_DIR="$(pwd)"
+FIREBASE_CONSTANTS_FILENAME="$(basename "$FIREBASE_CONSTANTS")"
+FIREBASE_CONSTANTS_FILE="$FIREBASE_CONSTANTS_DIR/$FIREBASE_CONSTANTS_FILENAME"
+
+
+CRYPTO_TOKEN="$2"
+if [ ! -f "$CRYPTO_TOKEN" ]; then
+  echo "could not find CRYPTO_TOKEN: $CRYPTO_TOKEN"
   exit 1
 fi
+
+cd "$(dirname "$CRYPTO_TOKEN")"
+CRYPTO_TOKEN_DIR="$(pwd)"
+CRYPTO_TOKEN_FILENAME="$(basename "$CRYPTO_TOKEN")"
+CRYPTO_TOKEN_FILE="$CRYPTO_TOKEN_DIR/$CRYPTO_TOKEN_FILENAME"
+
+########## validate that the firebase constants file and the crypto token point to the same project
+
+# Get the project id from the firebase constants file
+echo "getting project id from firebase constants..."
+FIREBASE_CONSTANTS_PROJECT_ID=$(cat $FIREBASE_CONSTANTS_FILE | python -c 'import json,sys; constants=json.load(sys.stdin); print(constants["projectId"])')
+echo "project id: $FIREBASE_CONSTANTS_PROJECT_ID"
+
+# Get the project id from the crypto token file
+echo "getting project id from crypto token..."
+CRYPTO_TOKEN_PROJECT_ID=$(cat $CRYPTO_TOKEN_FILE | python -c 'import json,sys; constants=json.load(sys.stdin); print(constants["project_id"])')
+echo "project id: $CRYPTO_TOKEN_PROJECT_ID"
+
+if [ "$FIREBASE_CONSTANTS_PROJECT_ID" != "$CRYPTO_TOKEN_PROJECT_ID" ]; then
+  echo "the two project ids must match, check that you're deploying to the correct project"
+  exit 1
+fi
+
+########## cd to the nook project directory and get the absolute path
+
+cd "$WORK_DIR"
+
+cd "$(dirname "$0")"/..
+PROJECT_DIR="$(pwd)"
 
 ########## ensure that node modules have been installed
 
+echo ""
 echo "node version $(node --version)"
-if [ ! -d "$PROJDIR/functions/node_modules" ]; then
-  echo "before deploying, run 'npm install' in $PROJDIR/functions"
+if [ ! -d "$PROJECT_DIR/functions/node_modules" ]; then
+  echo "before deploying, run 'npm install' in $PROJECT_DIR/functions"
   exit 1
 fi
 
 ########## rebuild the webapp
+
+echo ""
 
 # Remove previous build if it exists
 rm -rf public
@@ -47,8 +80,10 @@ echo "build complete"
 mv build ../public
 cd ..
 
+echo ""
+
 # Copy the constants in the build folder
-cp $FIREBASE_CONSTANTS public/assets/firebase_constants.json
+cp $FIREBASE_CONSTANTS_FILE public/assets/firebase_constants.json
 
 # Copy the latest commit sha1 hash on origin/master into the build folder
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -66,22 +101,19 @@ echo "{\"metadata\": [ {$DEPLOY_DATA} ] }" > public_metadata_nook_app.json
 
 ########## deploy webapp
 
-# Get the project id
-echo "getting project id..."
-PROJECT_ID=$(cat $FIREBASE_CONSTANTS | python -c 'import json,sys; constants=json.load(sys.stdin); print(constants["projectId"])')
-echo "project id: $PROJECT_ID"
-
-# Deploy using the local firebase instance
-echo "deploying to firebase..."
-node $PROJDIR/functions/node_modules/.bin/firebase \
+# Deploy using the local firebase tool
+echo "deploying to $FIREBASE_CONSTANTS_PROJECT_ID firebase..."
+node $PROJECT_DIR/functions/node_modules/.bin/firebase \
   deploy \
-  --project $PROJECT_ID \
+  --project $FIREBASE_CONSTANTS_PROJECT_ID \
   --public public
 echo "firebase deploy result: $?"
 
+echo ""
 echo "updating nook webapp metadata..."
 cd tool
 pipenv run python json_to_firebase.py "$CRYPTO_TOKEN_FILE" ../public_metadata_nook_app.json
 cd ..
 
+echo ""
 echo "deployment complete"

--- a/tool/deploy_webapp.sh
+++ b/tool/deploy_webapp.sh
@@ -54,14 +54,14 @@ fi
 cd "$WORK_DIR"
 
 cd "$(dirname "$0")"/..
-PROJECT_DIR="$(pwd)"
+NOOK_DIR="$(pwd)"
 
 ########## ensure that node modules have been installed
 
 echo ""
 echo "node version $(node --version)"
-if [ ! -d "$PROJECT_DIR/functions/node_modules" ]; then
-  echo "before deploying, run 'npm install' in $PROJECT_DIR/functions"
+if [ ! -d "$NOOK_DIR/functions/node_modules" ]; then
+  echo "before deploying, run 'npm install' in $NOOK_DIR/functions"
   exit 1
 fi
 
@@ -103,7 +103,7 @@ echo "{\"metadata\": [ {$DEPLOY_DATA} ] }" > public_metadata_nook_app.json
 
 # Deploy using the local firebase tool
 echo "deploying to $FIREBASE_CONSTANTS_PROJECT_ID firebase..."
-node $PROJECT_DIR/functions/node_modules/.bin/firebase \
+node $NOOK_DIR/functions/node_modules/.bin/firebase \
   deploy \
   --project $FIREBASE_CONSTANTS_PROJECT_ID \
   --public public


### PR DESCRIPTION
This introduces an upfront check between the firebase constants file and the crypto token to ensure that they both point to the same project.

It also fixes an issue where the script args needed to be passed either as absolute paths, or needed to be under the project repo root (because of the `cd "$(dirname "$0")"/..` command).