### PR TITLE
Make it harder to send multi messages with keyboard shortcuts

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -182,7 +182,8 @@ class UserData extends Data {
 
 class KeyPressData extends Data {
   String key;
-  KeyPressData(this.key);
+  bool hasModifierKey;
+  KeyPressData(this.key, this.hasModifierKey);
 
   @override
   String toString() => 'KeyPressData: {key: $key}';
@@ -232,7 +233,7 @@ class ToggleData extends Data {
 class SnackbarData extends Data {
   String text;
   SnackbarNotificationType type;
-  SnackbarData(text, type);
+  SnackbarData(this.text, this.type);
 
   @override
   String toString() => 'SnackbarData: {text: $text, type: $type}';
@@ -821,17 +822,14 @@ void command(UIAction action, Data data) {
         view.snackbarView.hideSnackbar();
       }
       // If the shortcut is for a reply, find it and send it
-      var selectedReply = suggestedRepliesByCategory[selectedSuggestedRepliesCategory].where((reply) => reply.shortcut == keyPressData.key);
+      var selectedReply = suggestedRepliesByCategory[selectedSuggestedRepliesCategory].where((reply) => reply.shortcut == keyPressData.key && !keyPressData.hasModifierKey);
       if (selectedReply.isNotEmpty) {
         assert (selectedReply.length == 1);
         if (!currentConfig.sendMultiMessageEnabled || selectedConversations.isEmpty) {
           sendReply(selectedReply.first, activeConversation);
           return;
         }
-        if (!view.sendingMultiMessagesUserConfirmation(selectedConversations.length)) {
-          return;
-        }
-        sendMultiReply(selectedReply.first, selectedConversations);
+        command(UIAction.showSnackbar, new SnackbarData('Cannot send multiple messages using keyboard shortcuts. Please use the send button on the suggested reply you want to send instead.', SnackbarNotificationType.warning));
         return;
       }
       // If the shortcut is for a tag and tag panel is enabled, find it and tag it to the conversation/message

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -821,8 +821,11 @@ void command(UIAction action, Data data) {
         // Hide the snackbar if it's visible
         view.snackbarView.hideSnackbar();
       }
+      // If the keypress it has a modifier key, prevent all replies and tags
+      if (keyPressData.hasModifierKey) return;
+
       // If the shortcut is for a reply, find it and send it
-      var selectedReply = suggestedRepliesByCategory[selectedSuggestedRepliesCategory].where((reply) => reply.shortcut == keyPressData.key && !keyPressData.hasModifierKey);
+      var selectedReply = suggestedRepliesByCategory[selectedSuggestedRepliesCategory].where((reply) => reply.shortcut == keyPressData.key);
       if (selectedReply.isNotEmpty) {
         assert (selectedReply.length == 1);
         if (!currentConfig.sendMultiMessageEnabled || selectedConversations.isEmpty) {

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -42,7 +42,9 @@ void init() {
       ..append(conversationListSelectView.panel)
       ..append(authHeaderView.authElement);
 
-  document.onKeyDown.listen((event) => command(UIAction.keyPressed, new KeyPressData(event.key)));
+  document.onKeyDown.listen(
+    (event) => command(UIAction.keyPressed,
+                       new KeyPressData(event.key, event.altKey || event.ctrlKey || event.metaKey || event.shiftKey)));
 }
 
 void initSignedInView() {


### PR DESCRIPTION
This PR does two things:
- it disables multi-message send with shortcuts - the user now has to use the explicit send button
- if a modifier key is pressed at the same time as another key, we don't send the matching suggested reply - this is to avoid sending messages when the user wants to use typical keyboard shortcuts in chrome (ctrl-c/ctrl-v/ctrl-0 etc)