### PR TITLE
set translation via publish add_opinion

### DIFF
--- a/webapp/lib/model.dart
+++ b/webapp/lib/model.dart
@@ -95,6 +95,7 @@ extension MessageUtil on g.Message {
     return pubSubClient.publishAddOpinion('nook_messages/set_translation', {
       "conversation_id": conversation.docId,
       "message_id": this.id,
+      "text": text,
       "translation": translation,
     });
   }

--- a/webapp/lib/model.dart
+++ b/webapp/lib/model.dart
@@ -90,12 +90,12 @@ extension MessageUtil on g.Message {
 
   Future<void> setTranslation(g.DocPubSubUpdate pubSubClient, g.Conversation conversation, String newTranslation) async {
     if (translation == newTranslation) return;
+    assert(this.id != null, "Expected non-null message identifier");
     translation = newTranslation;
-    return pubSubClient.publishDocChange(
-        g.Conversation.collectionName, <String>[
-      conversation.docId
-    ], {
-      "messages/${_messageIndex(conversation)}/translation": newTranslation
+    return pubSubClient.publishAddOpinion('nook_messages/set_translation', {
+      "conversation_id": conversation.docId,
+      "message_id": this.id,
+      "translation": translation,
     });
   }
 


### PR DESCRIPTION
This generates `add_opinion` when a translation is changed (see below).
Needs https://github.com/larksystems/Katikati-Core/pull/157 for pup/sub to forward this to piety.
```
{
   "datetime": "2020-05-27T01:57:54.340633+00:00",
   "src": "nook",
   "action": "add_opinion",
   "namespace": "nook_messages/set_translation",
   "opinion": {
      "conversation_id": "nook-phone-uuid-46d4a969-5ac7-4845-85de-8eb31c0dad16",
      "message_id": "nook-message-nook-phone-uuid-46d4a969-5ac7-4845-85de-8eb31c0dad16-f7d8a732bebbefa8822f0818bff39acdecd002db0c70f38a06110fbff573513e-10128",
      "text": "KAMA GANI",
      "translation": "Does this include the original text?",
      "_authenticatedUserEmail": "dan@lark.systems",
      "_authenticatedUserDisplayName": "Dan Rubel"
  }
}
```