### PR TITLE
modify conversation tag via add opinion

### DIFF
--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -90,7 +90,7 @@ class Conversation {
     tagIds.addAll(toBeAdded);
     return pubSubClient.publishAddOpinion('nook_conversations/add_tags', {
       'conversation_id': docId,
-      'tagIds': toBeAdded.toList(),
+      'tags': toBeAdded.toList(),
     });
   }
 
@@ -103,7 +103,7 @@ class Conversation {
     tagIds = newTagIds;
     return pubSubClient.publishAddOpinion('nook_conversations/set_tags', {
       'conversation_id': docId,
-      'tagIds': tagIds,
+      'tags': tagIds,
     });
   }
 
@@ -120,7 +120,7 @@ class Conversation {
     tagIds.removeAll(toBeRemoved);
     return pubSubClient.publishAddOpinion('nook_conversations/remove_tags', {
       'conversation_id': docId,
-      'tagIds': toBeRemoved.toList(),
+      'tags': toBeRemoved.toList(),
     });
   }
 

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -77,64 +77,51 @@ class Conversation {
     };
   }
 
-  /// Add [tagId] to tagIds in this Conversation.
+  /// Add [newTagIds] to tagIds in this Conversation.
   /// Callers should catch and handle IOException.
-  Future<void> addTagId(DocPubSubUpdate pubSubClient, String tagId) {
-    return addTagIdToAll(pubSubClient, [this], tagId);
-  }
-
-  /// Add [tagId] to tagIds in each Conversation.
-  /// Callers should catch and handle IOException.
-  static Future<void> addTagIdToAll(DocPubSubUpdate pubSubClient, List<Conversation> docs, String tagId) async {
-    final docIdsToPublish = <String>[];
-    for (var doc in docs) {
-      if (!doc.tagIds.contains(tagId)) {
-        doc.tagIds.add(tagId);
-        docIdsToPublish.add(doc.docId);
+  Future<void> addTagIds(DocPubSubUpdate pubSubClient, Iterable<String> newTagIds) {
+    var toBeAdded = Set<String>();
+    for (var elem in newTagIds) {
+      if (!tagIds.contains(elem)) {
+        toBeAdded.add(elem);
       }
     }
-    if (docIdsToPublish.isEmpty) return;
-    return pubSubClient.publishDocAdd(collectionName, docIdsToPublish, {"tags": [tagId]});
+    if (toBeAdded.isEmpty) return Future.value(null);
+    tagIds.addAll(toBeAdded);
+    return pubSubClient.publishAddOpinion('nook_conversations/add_tags', {
+      'conversation_id': docId,
+      'tagIds': toBeAdded.toList(),
+    });
   }
 
   /// Set tagIds in this Conversation.
   /// Callers should catch and handle IOException.
-  Future<void> setTagIds(DocPubSubUpdate pubSubClient, Set<String> tagIds) {
-    return setTagIdsForAll(pubSubClient, [this], tagIds);
+  Future<void> setTagIds(DocPubSubUpdate pubSubClient, Set<String> newTagIds) {
+    if (tagIds.length == newTagIds.length && tagIds.difference(newTagIds).isEmpty) {
+      return Future.value(null);
+    }
+    tagIds = newTagIds;
+    return pubSubClient.publishAddOpinion('nook_conversations/set_tags', {
+      'conversation_id': docId,
+      'tagIds': tagIds,
+    });
   }
 
-  /// Set tagIds in each Conversation.
+  /// Remove [oldTagIds] from tagIds in this Conversation.
   /// Callers should catch and handle IOException.
-  static Future<void> setTagIdsForAll(DocPubSubUpdate pubSubClient, List<Conversation> docs, Set<String> tagIds) async {
-    final docIdsToPublish = <String>[];
-    for (var doc in docs) {
-      if (doc.tagIds != tagIds) {
-        doc.tagIds = tagIds;
-        docIdsToPublish.add(doc.docId);
+  Future<void> removeTagIds(DocPubSubUpdate pubSubClient, Iterable<String> oldTagIds) {
+    var toBeRemoved = Set<String>();
+    for (var elem in oldTagIds) {
+      if (tagIds.contains(elem)) {
+        toBeRemoved.add(elem);
       }
     }
-    if (docIdsToPublish.isEmpty) return;
-    return pubSubClient.publishDocChange(collectionName, docIdsToPublish, {"tags": tagIds?.toList()});
-  }
-
-  /// Remove [tagId] from tagIds in this Conversation.
-  /// Callers should catch and handle IOException.
-  Future<void> removeTagId(DocPubSubUpdate pubSubClient, String tagId) {
-    return removeTagIdFromAll(pubSubClient, [this], tagId);
-  }
-
-  /// Remove [tagId] from tagIds in each Conversation.
-  /// Callers should catch and handle IOException.
-  static Future<void> removeTagIdFromAll(DocPubSubUpdate pubSubClient, List<Conversation> docs, String tagId) async {
-    final docIdsToPublish = <String>[];
-    for (var doc in docs) {
-      if (doc.tagIds.contains(tagId)) {
-        doc.tagIds.remove(tagId);
-        docIdsToPublish.add(doc.docId);
-      }
-    }
-    if (docIdsToPublish.isEmpty) return;
-    return pubSubClient.publishDocRemove(collectionName, docIdsToPublish, {"tags": [tagId]});
+    if (toBeRemoved.isEmpty) return Future.value(null);
+    tagIds.removeAll(toBeRemoved);
+    return pubSubClient.publishAddOpinion('nook_conversations/remove_tags', {
+      'conversation_id': docId,
+      'tagIds': toBeRemoved.toList(),
+    });
   }
 
   /// Set notes in this Conversation.

--- a/webapp/lib/model.yaml
+++ b/webapp/lib/model.yaml
@@ -4,6 +4,7 @@ ConversationListShard:
 
 Conversation:
   firebaseCollectionName: 'nook_conversations'
+  namespace:              'nook_conversations'
   demographicsInfo: 'map string'
   tags: 'publishable set string tagIds'
   messages: 'array Message'

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -283,15 +283,10 @@ Future<void> updateUnread(List<Conversation> conversations, bool newValue) {
 
 Future<void> addConversationTag(Conversation conversation, String tagId) {
   log.verbose("Adding tag $tagId to ${conversation.docId}");
-  return conversation.addTagId(_pubsubInstance, tagId);
-}
-
-Future<void> addConversationTag_forAll(List<Conversation> conversations, String tagId) {
-  log.verbose("Adding tag $tagId to ${conversations.length} conversations");
-  return Conversation.addTagIdToAll(_pubsubInstance, conversations, tagId);
+  return conversation.addTagIds(_pubsubInstance, [tagId]);
 }
 
 Future<void> removeConversationTag(Conversation conversation, String tagId) {
   log.verbose("Removing tag $tagId from ${conversation.docId}");
-  return conversation.removeTagId(_pubsubInstance, tagId);
+  return conversation.removeTagIds(_pubsubInstance, [tagId]);
 }


### PR DESCRIPTION
This changes nook to communicate conversation tag changes via published `add_opinion`:

Add tags:
```
{
   "datetime": "2020-05-27T16:49:24.177521+00:00",
   "src": "nook",
   "action": "add_opinion",
   "namespace": "nook_conversations/add_tags",
   "opinion": {
      "conversation_id": "nook-phone-uuid-46d4a969-5ac7-4845-85de-8eb31c0dad16",
      "tagIds": ["tag-029ddfbc"],
      "_authenticatedUserEmail": "dan@lark.systems",
      "_authenticatedUserDisplayName": "Dan Rubel"
   }
}
```
Remove tags:
```
{
   "datetime": "2020-05-27T16:49:30.809827+00:00",
   "src": "nook", "action": "add_opinion",
   "namespace": "nook_conversations/remove_tags",
   "opinion": {
      "conversation_id": "nook-phone-uuid-46d4a969-5ac7-4845-85de-8eb31c0dad16",
      "tagIds": ["tag-029ddfbc"],
      "_authenticatedUserEmail": "dan@lark.systems",
      "_authenticatedUserDisplayName": "Dan Rubel"
   }
}
```