### PR TITLE
set unread via add opinion

### DIFF
--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -159,22 +159,15 @@ class Conversation {
 
   /// Set unread in this Conversation.
   /// Callers should catch and handle IOException.
-  Future<void> setUnread(DocPubSubUpdate pubSubClient, bool unread) {
-    return setUnreadForAll(pubSubClient, [this], unread);
-  }
-
-  /// Set unread in each Conversation.
-  /// Callers should catch and handle IOException.
-  static Future<void> setUnreadForAll(DocPubSubUpdate pubSubClient, List<Conversation> docs, bool unread) async {
-    final docIdsToPublish = <String>[];
-    for (var doc in docs) {
-      if (doc.unread != unread) {
-        doc.unread = unread;
-        docIdsToPublish.add(doc.docId);
-      }
+  Future<void> setUnread(DocPubSubUpdate pubSubClient, bool newUnread) {
+    if (unread == newUnread) {
+      return Future.value(null);
     }
-    if (docIdsToPublish.isEmpty) return;
-    return pubSubClient.publishDocChange(collectionName, docIdsToPublish, {"unread": unread});
+    unread = newUnread;
+    return pubSubClient.publishAddOpinion('nook_conversations/set_unread', {
+      'conversation_id': docId,
+      'unread': unread,
+    });
   }
 
   String toString() => 'Conversation [$docId]: ${toData().toString()}';

--- a/webapp/lib/platform.dart
+++ b/webapp/lib/platform.dart
@@ -278,7 +278,11 @@ Future<void> updateUnread(List<Conversation> conversations, bool newValue) {
       ? conversations[0].docId
       : "${conversations.length} conversations"
   }");
-  return Conversation.setUnreadForAll(_pubsubInstance, conversations, newValue);
+  var futures = <Future>[];
+  for (var conversation in conversations) {
+    futures.add(conversation.setUnread(_pubsubInstance, newValue));
+  }
+  return Future.wait(futures);
 }
 
 Future<void> addConversationTag(Conversation conversation, String tagId) {


### PR DESCRIPTION
This changes nook to communicate unread flag changes via published `add_opinion`:
```
{
   "datetime": "2020-05-27T18:53:02.452270+00:00",
   "src": "nook",
   "action": "add_opinion",
   "namespace": "nook_conversations/set_unread",
   "opinion": {
      "conversation_id": "nook-phone-uuid-46d4a969-5ac7-4845-85de-8eb31c0dad16",
      "unread": true,
      "_authenticatedUserEmail": "dan@lark.systems",
      "_authenticatedUserDisplayName": "Dan Rubel"
   }
}
```