### PR TITLE
change setNotes to publish add_opinion

### DIFF
--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -139,22 +139,15 @@ class Conversation {
 
   /// Set notes in this Conversation.
   /// Callers should catch and handle IOException.
-  Future<void> setNotes(DocPubSubUpdate pubSubClient, String notes) {
-    return setNotesForAll(pubSubClient, [this], notes);
-  }
-
-  /// Set notes in each Conversation.
-  /// Callers should catch and handle IOException.
-  static Future<void> setNotesForAll(DocPubSubUpdate pubSubClient, List<Conversation> docs, String notes) async {
-    final docIdsToPublish = <String>[];
-    for (var doc in docs) {
-      if (doc.notes != notes) {
-        doc.notes = notes;
-        docIdsToPublish.add(doc.docId);
-      }
+  Future<void> setNotes(DocPubSubUpdate pubSubClient, String newNotes) {
+    if (notes == newNotes) {
+      return Future.value(null);
     }
-    if (docIdsToPublish.isEmpty) return;
-    return pubSubClient.publishDocChange(collectionName, docIdsToPublish, {"notes": notes});
+    notes = newNotes;
+    return pubSubClient.publishAddOpinion('nook_conversations/set_notes', {
+      'conversation_id': docId,
+      'notes': notes,
+    });
   }
 
   /// Set unread in this Conversation.


### PR DESCRIPTION
This changes nook to communicate notes changes via published `add_opinion`:
```
{
   "datetime": "2020-05-27T17:36:35.065945+00:00",
   "src": "nook", "action": "add_opinion",
   "namespace": "nook_conversations/set_notes",
   "opinion": {
      "conversation_id": "nook-phone-uuid-46d4a969-5ac7-4845-85de-8eb31c0dad16",
      "notes": "Some new notes vis",
      "_authenticatedUserEmail": "dan@lark.systems",
      "_authenticatedUserDisplayName": "Dan Rubel"
   }
}
```
