### PR TITLE
Pre-compute UUID set during updateConversationList

### DIFF
--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -769,8 +769,12 @@ class ConversationListPanelView {
   }
 
   void updateConversationList(Set<Conversation> conversations) {
+    Set<String> uuidSets = Set<String>();
+    for (Conversation c in conversations) {
+      uuidSets.add(c.docId);
+    }
     _phoneToConversations.removeWhere((String uuid, ConversationSummary summary) {
-      if (conversations.any((c) => c.docId == uuid)) return false;
+      if (uuidSets.contains(uuid)) return false;
       _conversationList.removeItem(summary);
       return true;
     });


### PR DESCRIPTION
Please take a look - I think this is behaviourally identical, but improves runtime from 7000ms to 50ms for 7000 items.