### PR TITLE
Add implementation for filtering hierarchical tags

### DIFF
--- a/webapp/lib/controller_view_helper.dart
+++ b/webapp/lib/controller_view_helper.dart
@@ -156,7 +156,7 @@ Map<String, List<model.SuggestedReply>> _groupRepliesIntoCategories(List<model.S
 Map<String, List<model.Tag>> _groupTagsIntoCategories(List<model.Tag> tags) {
   Map<String, List<model.Tag>> result = {};
   for (model.Tag tag in tags) {
-    result.putIfAbsent(tag.category, () => []).add(tag);
+    result.putIfAbsent(tag.group, () => []).add(tag);
   }
   return result;
 }

--- a/webapp/lib/controller_view_helper.dart
+++ b/webapp/lib/controller_view_helper.dart
@@ -152,3 +152,15 @@ Map<String, List<model.SuggestedReply>> _groupRepliesIntoCategories(List<model.S
   }
   return result;
 }
+
+Map<String, List<model.Tag>> _groupTagsIntoCategories(List<model.Tag> tags) {
+  Map<String, List<model.Tag>> result = {};
+  for (model.Tag tag in tags) {
+    String category = tag.category ?? '';
+    if (!result.containsKey(category)) {
+      result[category] = [];
+    }
+    result[category].add(tag);
+  }
+  return result;
+}

--- a/webapp/lib/controller_view_helper.dart
+++ b/webapp/lib/controller_view_helper.dart
@@ -156,11 +156,7 @@ Map<String, List<model.SuggestedReply>> _groupRepliesIntoCategories(List<model.S
 Map<String, List<model.Tag>> _groupTagsIntoCategories(List<model.Tag> tags) {
   Map<String, List<model.Tag>> result = {};
   for (model.Tag tag in tags) {
-    String category = tag.category ?? '';
-    if (!result.containsKey(category)) {
-      result[category] = [];
-    }
-    result[category].add(tag);
+    result.putIfAbsent(tag.category, () => []).add(tag);
   }
   return result;
 }

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -373,7 +373,7 @@ class Tag {
       ..type = TagType.fromString(data['type'] as String) ?? TagType.Normal
       ..shortcut = String_fromData(data['shortcut'])
       ..filterable = bool_fromData(data['filterable'])
-      ..category = String_fromData(data['category']);
+      ..category = String_fromData(data['category']) ?? '';
   }
 
   static void listen(DocStorage docStorage, TagCollectionListener listener, String collectionRoot) =>

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -359,7 +359,7 @@ class Tag {
   TagType type;
   String shortcut;
   bool filterable;
-  String category;
+  String group;
 
   String get tagId => docId;
 
@@ -373,7 +373,7 @@ class Tag {
       ..type = TagType.fromString(data['type'] as String) ?? TagType.Normal
       ..shortcut = String_fromData(data['shortcut'])
       ..filterable = bool_fromData(data['filterable'])
-      ..category = String_fromData(data['category']) ?? '';
+      ..group = String_fromData(data['group']) ?? '';
   }
 
   static void listen(DocStorage docStorage, TagCollectionListener listener, String collectionRoot) =>
@@ -385,7 +385,7 @@ class Tag {
       if (type != null) 'type': type.toString(),
       if (shortcut != null) 'shortcut': shortcut,
       if (filterable != null) 'filterable': filterable,
-      if (category != null) 'category': category,
+      if (group != null) 'group': group,
     };
   }
 

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -359,6 +359,7 @@ class Tag {
   TagType type;
   String shortcut;
   bool filterable;
+  String category;
 
   String get tagId => docId;
 
@@ -371,7 +372,8 @@ class Tag {
       ..text = String_fromData(data['text'])
       ..type = TagType.fromString(data['type'] as String) ?? TagType.Normal
       ..shortcut = String_fromData(data['shortcut'])
-      ..filterable = bool_fromData(data['filterable']);
+      ..filterable = bool_fromData(data['filterable'])
+      ..category = String_fromData(data['category']);
   }
 
   static void listen(DocStorage docStorage, TagCollectionListener listener, String collectionRoot) =>
@@ -383,6 +385,7 @@ class Tag {
       if (type != null) 'type': type.toString(),
       if (shortcut != null) 'shortcut': shortcut,
       if (filterable != null) 'filterable': filterable,
+      if (category != null) 'category': category,
     };
   }
 

--- a/webapp/lib/model.yaml
+++ b/webapp/lib/model.yaml
@@ -51,6 +51,7 @@ Tag:
   type: 'TagType, TagType.Normal'
   shortcut: 'string'
   filterable: 'bool'
+  category: 'string'
 
 TagType:
   dartType: 'enum'

--- a/webapp/lib/model.yaml
+++ b/webapp/lib/model.yaml
@@ -51,7 +51,7 @@ Tag:
   type: 'TagType, TagType.Normal'
   shortcut: 'string'
   filterable: 'bool'
-  category: 'string'
+  group: 'string'
 
 TagType:
   dartType: 'enum'

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -882,6 +882,8 @@ class ConversationFilter {
   DivElement conversationFilter;
   DivElement _tagsContainer;
   DivElement _tagsMenu;
+  DivElement _tagsMenuWrapper;
+  SelectElement _tagCategories;
   DivElement _tagsMenuContainer;
 
   ConversationFilter() {
@@ -895,9 +897,17 @@ class ConversationFilter {
     _tagsMenu = new DivElement()
       ..classes.add('tags-menu');
 
+    _tagsMenuWrapper = new DivElement()
+      ..classes.add('tags-menu__wrapper');
+    _tagsMenu.append(_tagsMenuWrapper);
+
+    _tagCategories = new SelectElement();
+    _tagCategories.onChange.listen((_) => command(UIAction.updateFilterTagsCategory, new UpdateFilterTagsCategoryData(_tagCategories.value)));
+    _tagsMenuWrapper.append(_tagCategories);
+
     _tagsMenuContainer = new DivElement()
       ..classes.add('tags-menu__container');
-    _tagsMenu.append(_tagsMenuContainer);
+    _tagsMenuWrapper.append(_tagsMenuContainer);
 
     conversationFilter.append(_tagsMenu);
 
@@ -932,6 +942,27 @@ class ConversationFilter {
       _tagsMenuContainer.firstChild.remove();
     }
     assert(_tagsMenuContainer.children.length == 0);
+  }
+
+  set selectedCategory(String category) {
+    int index = _tagCategories.children.indexWhere((Element option) => (option as OptionElement).value == category);
+    if (index == -1) {
+      showWarningStatus("Couldn't find $category in list of suggested replies category, using first");
+      _tagCategories.selectedIndex = 0;
+      command(UIAction.updateFilterTagsCategory, new UpdateFilterTagsCategoryData(_tagCategories.value));
+      return;
+    }
+    _tagCategories.selectedIndex = index;
+  }
+
+  set categories(List<String> categories) {
+    _tagCategories.children.clear();
+    for (var category in categories) {
+      _tagCategories.append(
+        new OptionElement()
+          ..value = category
+          ..text = category);
+    }
   }
 }
 

--- a/webapp/web/styles.css
+++ b/webapp/web/styles.css
@@ -73,7 +73,7 @@ main {
     visibility: visible;
 }
 
-.tags-menu__container {
+.tags-menu__wrapper {
     position: absolute;
     width: 450px;
     height: auto;
@@ -86,7 +86,7 @@ main {
     margin: 16px;
 }
 
-.tags-menu__container::before {
+.tags-menu__wrapper::before {
     content: '';
     width: 150px;
     height: 100%;
@@ -94,6 +94,11 @@ main {
     opacity: 0;
     position: absolute;
     left: -150px;
+}
+
+.tags-menu__container {
+    max-height: 300px;
+    overflow-y: scroll;
 }
 
 .conversation-list-panel {


### PR DESCRIPTION
This PR addresses #349 by:
- adding categories for tags in the same way that we have added for suggested replies
- using the categories in the filtering UI via a category selector
- also setting an upper limit on the height of the tag filtering menu making the list to scroll if there are too many tags, this should make it more usable even when we're not using categories