### PR TITLE
remove unused functionality

### DIFF
--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -587,19 +587,4 @@ abstract class DocBatchUpdate {
 abstract class DocPubSubUpdate {
   /// Publish the given opinion for the given namespace.
   Future<void> publishAddOpinion(String namespace, Map<String, dynamic> opinion);
-
-  /// Publish the given document list/set additions,
-  /// where [additions] is a mapping of field name to new values to be added to the list/set.
-  /// Callers should catch and handle IOException.
-  Future<void> publishDocAdd(String collectionName, List<String> docIds, Map<String, List<dynamic>> additions);
-
-  /// Publish the given document changes,
-  /// where [changes] is a mapping of field name to new value.
-  /// Callers should catch and handle IOException.
-  Future<void> publishDocChange(String collectionName, List<String> docIds, Map<String, dynamic> changes);
-
-  /// Publish the given document list/set removals,
-  /// where [removals] is a mapping of field name to old values to be removed from the list/set.
-  /// Callers should catch and handle IOException.
-  Future<void> publishDocRemove(String collectionName, List<String> docIds, Map<String, List<dynamic>> removals);
 }

--- a/webapp/lib/pubsub.dart
+++ b/webapp/lib/pubsub.dart
@@ -61,39 +61,6 @@ class PubSubClient extends DocPubSubUpdate {
       "opinion": opinion,
     });
   }
-
-  @override
-  Future<void> publishDocAdd(String collectionName, List<String> docIds,
-      Map<String, List<dynamic>> additions) {
-    return publish(platform_constants.smsTopic, {
-      "action": "update_firebase",
-      "collection": collectionName,
-      "ids": docIds,
-      "additions": additions,
-    });
-  }
-
-  @override
-  Future<void> publishDocChange(String collectionName, List<String> docIds,
-      Map<String, dynamic> changes) {
-    return publish(platform_constants.smsTopic, {
-      "action": "update_firebase",
-      "collection": collectionName,
-      "ids": docIds,
-      "changes": changes,
-    });
-  }
-
-  @override
-  Future<void> publishDocRemove(String collectionName, List<String> docIds,
-      Map<String, List<dynamic>> removals) {
-    return publish(platform_constants.smsTopic, {
-      "action": "update_firebase",
-      "collection": collectionName,
-      "ids": docIds,
-      "removals": removals,
-    });
-  }
 }
 
 class PubSubException implements Exception {


### PR DESCRIPTION
This removes functionality that supports "publish `update_firebase`"
now that we have switched over entirely to use "publish `add_opinion`"