### PR TITLE
Various layout fixes

### DIFF
--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -84,18 +84,35 @@ void clearMain() {
 }
 
 void showTagPanel() {
-  tagPanelView.tagPanel.classes.toggle('hidden', false);
-  conversationListPanelView.conversationListPanel.classes.add('w-20');
-  conversationPanelView.conversationPanel.classes.add('w-40');
-  replyPanelView.replyPanel.classes.add('w-25');
-  tagPanelView.tagPanel.classes.add('w-15');
+  tagPanelView.tagPanel.classes
+    ..toggle('hidden', false)
+    ..toggle('w-0', false)
+    ..toggle('w-15', true);
+  conversationListPanelView.conversationListPanel.classes
+    ..toggle('w-25', false)
+    ..toggle('w-20', true);
+  conversationPanelView.conversationPanel.classes
+    ..toggle('w-45', false)
+    ..toggle('w-40', true);
+  replyPanelView.replyPanel.classes
+    ..toggle('w-30', false)
+    ..toggle('w-25', true);
 }
 
 void hideTagPanel() {
-  tagPanelView.tagPanel.classes.toggle('hidden', true);
-  conversationListPanelView.conversationListPanel.classes.add('w-25');
-  conversationPanelView.conversationPanel.classes.add('w-45');
-  replyPanelView.replyPanel.classes.add('w-30');
+  tagPanelView.tagPanel.classes
+    ..toggle('hidden', true)
+    ..toggle('w-0', true)
+    ..toggle('w-15', false);
+  conversationListPanelView.conversationListPanel.classes
+    ..toggle('w-25', true)
+    ..toggle('w-20', false);
+  conversationPanelView.conversationPanel.classes
+    ..toggle('w-45', true)
+    ..toggle('w-40', false);
+  replyPanelView.replyPanel.classes
+    ..toggle('w-30', true)
+    ..toggle('w-25', false);
 }
 
 bool sendingMultiMessagesUserConfirmation(int noMessages) {
@@ -1282,6 +1299,7 @@ class ActionView {
 
     var buttonElement = new DivElement()
       ..classes.add('action__button')
+      ..classes.add('action__button--float')
       ..text = buttonText;
     action.append(buttonElement);
   }
@@ -1311,7 +1329,7 @@ class ReplyActionView extends ActionView {
 
     { // Add text
       var textWrapper = new DivElement()
-        ..style.display = 'flex';
+        ..style.position = 'relative';
       textTranslationWrapper.append(textWrapper);
 
       var descriptionElement = new DivElement()
@@ -1333,7 +1351,7 @@ class ReplyActionView extends ActionView {
 
     { // Add translation
       var translationWrapper = new DivElement()
-        ..style.display = 'flex';
+        ..style.position = 'relative';
       textTranslationWrapper.append(translationWrapper);
 
       var descriptionElement = new DivElement()

--- a/webapp/web/actions.css
+++ b/webapp/web/actions.css
@@ -20,6 +20,7 @@
 
 .action__description {
   flex:  1 1 auto;
+  word-break: break-word;
 }
 
 .action__translation {
@@ -44,6 +45,7 @@
   box-shadow: 0 0 5px 4px #eee;
   position: absolute;
   right: 0;
+  top: 0;
 }
 
 .new-message-box__send-button {

--- a/webapp/web/messages.css
+++ b/webapp/web/messages.css
@@ -20,7 +20,7 @@
   border-radius: 6px;
   flex: 0 1 auto;
   flex-wrap: inherit;
-  word-wrap: break-word;
+  word-break: break-word;
   overflow: hidden;
 }
 

--- a/webapp/web/styles.css
+++ b/webapp/web/styles.css
@@ -151,6 +151,7 @@ main {
     display: flex;
     border-bottom: 1px solid lightgray;
     border-left: 5px solid #fff;
+    word-break: break-word;
 }
 
 .conversation-list__item:hover {

--- a/webapp/web/utilities.css
+++ b/webapp/web/utilities.css
@@ -1,6 +1,7 @@
 
 /*** Widths */
 
+.w-0 { width: 0%; }
 .w-05 { width: 05%; }
 .w-10 { width: 10%; }
 .w-15 { width: 15%; }


### PR DESCRIPTION
* Fixes #379 which was caused by the not removing the width classes between tag panel visibility changes
* Long tag names without spaces in the tag panel will break on multiple lines if there's not enough space for them in the panel
* "Tag" buttons are also now floating over the text of the tag (as for the suggested replies)