### PR TITLE
Fix errors thrown when the active conversation is no longer in the list view

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -719,10 +719,7 @@ void command(UIAction action, Data data) {
     case UIAction.markConversationRead:
       ConversationData conversationData = data;
       model.Conversation conversation = conversations.singleWhere((c) => c.docId == conversationData.deidentifiedPhoneNumber);
-      if (filteredConversations.contains(conversation)) {
-        // Update the conversation list UI only if it's in the list
-        view.conversationListPanelView.markConversationRead(conversationData.deidentifiedPhoneNumber);
-      }
+      view.conversationListPanelView.markConversationRead(conversation.docId);
       platform.updateUnread([conversation], false).catchError(showAndLogError);
       break;
     case UIAction.markConversationUnread:
@@ -991,6 +988,7 @@ void updateViewForConversation(model.Conversation conversation) {
     // Select the conversation in the list
     view.conversationListPanelView.selectConversation(conversation.docId);
   } else {
+    // If it's not in the list, show warning
     view.conversationPanelView.showWarning('Conversation no longer meets filtering constraints');
   }
 }

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -514,8 +514,10 @@ void conversationListSelected(String conversationListRoot) {
       // Update the active conversation view as needed
       if (updatedIds.contains(activeConversation.docId)) {
         updateViewForConversation(activeConversation);
+        if (!activeConversation.unread) {
+          command(UIAction.markConversationRead, ConversationData(activeConversation.docId));
+        }
       }
-      command(UIAction.markConversationRead, ConversationData(activeConversation.docId));
     },
     conversationListRoot);
 }
@@ -716,8 +718,12 @@ void command(UIAction action, Data data) {
       break;
     case UIAction.markConversationRead:
       ConversationData conversationData = data;
-      view.conversationListPanelView.markConversationRead(conversationData.deidentifiedPhoneNumber);
-      platform.updateUnread([activeConversation], false).catchError(showAndLogError);
+      model.Conversation conversation = conversations.singleWhere((c) => c.docId == conversationData.deidentifiedPhoneNumber);
+      if (filteredConversations.contains(conversation)) {
+        // Update the conversation list UI only if it's in the list
+        view.conversationListPanelView.markConversationRead(conversationData.deidentifiedPhoneNumber);
+      }
+      platform.updateUnread([conversation], false).catchError(showAndLogError);
       break;
     case UIAction.markConversationUnread:
       if (!currentConfig.sendMultiMessageEnabled || selectedConversations.isEmpty) {
@@ -968,8 +974,6 @@ model.Conversation updateViewForConversations(Set<model.Conversation> conversati
 
 void updateViewForConversation(model.Conversation conversation) {
   if (conversation == null) return;
-  // Select the conversation in the list
-  view.conversationListPanelView.selectConversation(conversation.docId);
   // Replace the previous conversation in the conversation panel
   _populateConversationPanelView(conversation);
   view.replyPanelView.noteText = conversation.notes;
@@ -982,6 +986,12 @@ void updateViewForConversation(model.Conversation conversation) {
       view.conversationPanelView.deselectMessage();
       _populateTagPanelView(conversationTags, TagReceiver.Conversation);
       break;
+  }
+  if (filteredConversations.contains(conversation)) {
+    // Select the conversation in the list
+    view.conversationListPanelView.selectConversation(conversation.docId);
+  } else {
+    view.conversationPanelView.showWarning('Conversation no longer meets filtering constraints');
   }
 }
 

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -852,19 +852,19 @@ class ConversationListPanelView {
   }
 
   void markConversationRead(String deidentifiedPhoneNumber) {
-    _phoneToConversations[deidentifiedPhoneNumber]._markRead();
+    _phoneToConversations[deidentifiedPhoneNumber]?._markRead();
   }
 
   void markConversationUnread(String deidentifiedPhoneNumber) {
-    _phoneToConversations[deidentifiedPhoneNumber]._markUnread();
+    _phoneToConversations[deidentifiedPhoneNumber]?._markUnread();
   }
 
   void checkConversation(String deidentifiedPhoneNumber) {
-    _phoneToConversations[deidentifiedPhoneNumber]._check();
+    _phoneToConversations[deidentifiedPhoneNumber]?._check();
   }
 
   void uncheckConversation(String deidentifiedPhoneNumber) {
-    _phoneToConversations[deidentifiedPhoneNumber]._uncheck();
+    _phoneToConversations[deidentifiedPhoneNumber]?._uncheck();
   }
 
   void checkAllConversations() => _phoneToConversations.forEach((_, conversation) => conversation._check());


### PR DESCRIPTION
Fixes #383 

By keeping the active conversation on the screen even when it no longer meets filtering constraints, the `activeConversation.docId` may not be in the `view.conversationListPanelView`. This PR addresses this by checking if it is there before trying to select it and adding null checks for markUnread/check operations.