### PR TITLE
Add @charset utf-8 to css files to specify encoding

### DIFF
--- a/webapp/web/actions.css
+++ b/webapp/web/actions.css
@@ -1,3 +1,4 @@
+@charset "utf-8";
 
 .action-list {
   flex: 1 1 auto;

--- a/webapp/web/banner.css
+++ b/webapp/web/banner.css
@@ -1,3 +1,5 @@
+@charset "utf-8";
+
 #banner {
   flex: 0 0 auto;
   width: 100%;

--- a/webapp/web/load_spinner.css
+++ b/webapp/web/load_spinner.css
@@ -1,3 +1,5 @@
+@charset "utf-8";
+
 .load-spinner {
   margin-top: 24px;
   margin-left: auto;

--- a/webapp/web/messages.css
+++ b/webapp/web/messages.css
@@ -1,3 +1,5 @@
+@charset "utf-8";
+
 .message {
   border-radius: 6px;
   display: flex;

--- a/webapp/web/reset.css
+++ b/webapp/web/reset.css
@@ -1,3 +1,5 @@
+@charset "utf-8";
+
 /*
 Reset stylesheet
 Modified from

--- a/webapp/web/snackbar.css
+++ b/webapp/web/snackbar.css
@@ -1,3 +1,5 @@
+@charset "utf-8";
+
 #snackbar {
   position: fixed;
   left: 50%;

--- a/webapp/web/styles.css
+++ b/webapp/web/styles.css
@@ -1,3 +1,5 @@
+@charset "utf-8";
+
 body {
     font-family: sans-serif;
     font-style: normal;

--- a/webapp/web/tags.css
+++ b/webapp/web/tags.css
@@ -1,3 +1,5 @@
+@charset "utf-8";
+
 .tag {
   font-size: 12px;
   font-style: italic;

--- a/webapp/web/utilities.css
+++ b/webapp/web/utilities.css
@@ -1,3 +1,4 @@
+@charset "utf-8";
 
 /*** Widths */
 


### PR DESCRIPTION
This at-rule is useful for using non-ASCII characters in some CSS properties (e.g. content), which we do for the new filter menu (I caught the browser not interpreting this correctly today for some reason).