### PR TITLE
Don't try to remove tags that don't exist.

### DIFF
--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -989,6 +989,10 @@ class ConversationFilter {
 
   void removeMenuTag(FilterMenuTagView tag, String category) {
     int index = _tagGroups[category].indexWhere((t) => t.tag.dataset["id"] == tag.tag.dataset["id"]);
+    if (index < 0) {
+      log.warning("Trying to remove a tag that doesn't exist in the menu: ${tag.tag.dataset["id"]}");
+      return;
+    }
     _tagGroups[category][index].tag.remove();
     _tagGroups[category].removeAt(index);
   }


### PR DESCRIPTION
This shouldn't happen, but the missing tag lists don't seem to work well, causing attempts to remove tags that are not the the view. It's a stop gap fix until we find the proper cause for this issue.