### PR TITLE
Fix issue where tags were removed from view but not app controller state

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -1163,6 +1163,7 @@ void updateMissingTagIds(Set<model.Conversation> conversations, List<model.Tag> 
   var tagIdsToRemove = tagIdsWithMissingInfo.difference(newTagIdsWithMissingInfo);
   if (tagIdsToRemove.isNotEmpty) {
     var tagsToRemove = tagIdsToTags(tagIdsToRemove, conversationTags);
+    conversationTags.removeWhere((tag) => tagsToRemove.contains(tag));
     _removeTagsFromFilterMenu({tagsToRemove.first.group: tagsToRemove});
   }
   // add tags that are new


### PR DESCRIPTION
It turns out the proper fix for #395 is fairly simple - we were only removing them from the view, but not from the internal app state. 