### PR TITLE
Fix last turn inbound tags filter list being null instead of empty

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -614,9 +614,9 @@ void conversationListSelected(String conversationListRoot) {
       filterTags = tagIdsToTags(filterTagIds, conversationTags).toList();
       _populateSelectedFilterTags(filterTags);
 
+      filterLastInboundTurnTags = [];
       if (currentConfig.conversationalTurnsEnabled) {
         // Get turn filters from the url
-        filterLastInboundTurnTags = [];
         _populateSelectedFilterTurnTags(filterLastInboundTurnTags);
       }
 


### PR DESCRIPTION
This was introduced in #404 and was causing Nook not to load for users with the conversational turns feature disabled

TBR