### PR TITLE
Replace asserts with explicit error throwing

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -808,10 +808,12 @@ void command(UIAction action, Data data) {
     case UIAction.removeMessageTag:
       MessageTagData messageTagData = data;
       var message = activeConversation.messages[messageTagData.messageIndex];
-      platform.removeMessageTag(activeConversation, message, messageTagData.tagId).catchError(showAndLogError);
-      view.conversationPanelView
-        .messageViewAtIndex(messageTagData.messageIndex)
-        .removeTag(messageTagData.tagId);
+      platform.removeMessageTag(activeConversation, message, messageTagData.tagId).then(
+        (_) {
+          view.conversationPanelView
+            .messageViewAtIndex(messageTagData.messageIndex)
+            .removeTag(messageTagData.tagId);
+        }, onError: showAndLogError);
       break;
     case UIAction.removeFilterTag:
       FilterTagData tagData = data;
@@ -933,7 +935,7 @@ void command(UIAction action, Data data) {
           "${conversation.docId}.message-${messageTranslation.messageIndex}.translation",
           messageTranslation.translationText,
           (newText) {
-            return platform.setMessageTranslation(conversation, message, newText);
+            return platform.setMessageTranslation(conversation, message, newText).catchError(showAndLogError);
           },
         );
       }
@@ -1250,10 +1252,12 @@ void setMultiConversationTag(model.Tag tag, List<model.Conversation> conversatio
 
 void setMessageTag(model.Tag tag, model.Message message, model.Conversation conversation) {
   if (!message.tagIds.contains(tag.tagId)) {
-    platform.addMessageTag(activeConversation, message, tag.tagId).catchError(showAndLogError);
-    view.conversationPanelView
-      .messageViewAtIndex(conversation.messages.indexOf(message))
-      .addTag(new view.MessageTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
+    platform.addMessageTag(activeConversation, message, tag.tagId).then(
+      (_) {
+        view.conversationPanelView
+          .messageViewAtIndex(conversation.messages.indexOf(message))
+          .addTag(new view.MessageTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
+      }, onError: showAndLogError);
   }
 }
 

--- a/webapp/lib/model.dart
+++ b/webapp/lib/model.dart
@@ -1,5 +1,3 @@
-import 'dart:collection';
-
 import 'model.g.dart' as g;
 export 'model.g.dart' hide
   MessageDirection_fromStringOverride,
@@ -72,7 +70,9 @@ extension MessageUtil on g.Message {
   /// Callers should catch and handle IOException.
   Future<void> addTagId(g.DocPubSubUpdate pubSubClient, g.Conversation conversation, String tagId) async {
     if (tagIds.contains(tagId)) return;
-    assert(this.id != null, "Expected non-null message identifier");
+    if (this.id == null) {
+      throw ArgumentError('Cannot add tag to a pending message - please try again in a few seconds');
+    }
     tagIds.add(tagId);
     return pubSubClient.publishAddOpinion('nook_messages/add_tags', {
       "conversation_id": conversation.docId,
@@ -85,7 +85,9 @@ extension MessageUtil on g.Message {
   /// Callers should catch and handle IOException.
   Future<void> removeTagId(g.DocPubSubUpdate pubSubClient, g.Conversation conversation, String tagId) async {
     if (!tagIds.contains(tagId)) return;
-    assert(this.id != null, "Expected non-null message identifier");
+    if (this.id == null) {
+      throw ArgumentError('Cannot remove a tag from a pending message - please try again in a few seconds');
+    }
     tagIds.remove(tagId);
     return pubSubClient.publishAddOpinion('nook_messages/remove_tags', {
       "conversation_id": conversation.docId,
@@ -96,7 +98,9 @@ extension MessageUtil on g.Message {
 
   Future<void> setTranslation(g.DocPubSubUpdate pubSubClient, g.Conversation conversation, String newTranslation) async {
     if (translation == newTranslation) return;
-    assert(this.id != null, "Expected non-null message identifier");
+    if (this.id == null) {
+      throw ArgumentError('Cannot add translation of a pending message - please try again in a few seconds');
+    }
     translation = newTranslation;
     return pubSubClient.publishAddOpinion('nook_messages/set_translation', {
       "conversation_id": conversation.docId,

--- a/webapp/lib/model.dart
+++ b/webapp/lib/model.dart
@@ -71,7 +71,7 @@ extension MessageUtil on g.Message {
   Future<void> addTagId(g.DocPubSubUpdate pubSubClient, g.Conversation conversation, String tagId) async {
     if (tagIds.contains(tagId)) return;
     if (this.id == null) {
-      throw ArgumentError('Cannot add tag to a pending message - please try again in a few seconds');
+      throw AssertionError('Cannot add tag to a pending message - please try again in a few seconds');
     }
     tagIds.add(tagId);
     return pubSubClient.publishAddOpinion('nook_messages/add_tags', {
@@ -86,7 +86,7 @@ extension MessageUtil on g.Message {
   Future<void> removeTagId(g.DocPubSubUpdate pubSubClient, g.Conversation conversation, String tagId) async {
     if (!tagIds.contains(tagId)) return;
     if (this.id == null) {
-      throw ArgumentError('Cannot remove a tag from a pending message - please try again in a few seconds');
+      throw AssertionError('Cannot remove a tag from a pending message - please try again in a few seconds');
     }
     tagIds.remove(tagId);
     return pubSubClient.publishAddOpinion('nook_messages/remove_tags', {
@@ -99,7 +99,7 @@ extension MessageUtil on g.Message {
   Future<void> setTranslation(g.DocPubSubUpdate pubSubClient, g.Conversation conversation, String newTranslation) async {
     if (translation == newTranslation) return;
     if (this.id == null) {
-      throw ArgumentError('Cannot add translation of a pending message - please try again in a few seconds');
+      throw AssertionError('Cannot add translation of a pending message - please try again in a few seconds');
     }
     translation = newTranslation;
     return pubSubClient.publishAddOpinion('nook_messages/set_translation', {


### PR DESCRIPTION
I always forget that dart2js compilation strips off asserts... not sure if there's a compilation flag we could pass for it not to do that?

In any case, this replaces the asserts with explicit error that can also be interpreted by the user, and also makes the internal state dependent on whether there was an error thrown or not for tags (beforehand, the tag was added/removed regardless of whether the error was being thrown, and because of the previous check to avoid adding/removing the tag again, it could never be added/removed later on). For translations, the user can trigger another save by editing the translation - I'd rather not delete the text they just wrote. But if you have any thoughts as to a better behaviour, plmk.

Thanks!