### PR TITLE
remove unused enum fromStringOverride functionality

### DIFF
--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -204,10 +204,6 @@ class MessageDirection {
   ];
 
   static MessageDirection fromString(String text, [MessageDirection defaultValue = MessageDirection.Out]) {
-    if (MessageDirection_fromStringOverride != null) {
-      var value = MessageDirection_fromStringOverride(text);
-      if (value != null) return value;
-    }
     if (text != null) {
       const prefix = 'MessageDirection.';
       String valueName = text.startsWith(prefix) ? text.substring(prefix.length) : text;
@@ -223,7 +219,6 @@ class MessageDirection {
   const MessageDirection(this.name);
   String toString() => 'MessageDirection.$name';
 }
-MessageDirection Function(String text) MessageDirection_fromStringOverride;
 
 class MessageStatus {
   static const pending = MessageStatus('pending');
@@ -239,10 +234,6 @@ class MessageStatus {
   ];
 
   static MessageStatus fromString(String text, [MessageStatus defaultValue = MessageStatus.unknown]) {
-    if (MessageStatus_fromStringOverride != null) {
-      var value = MessageStatus_fromStringOverride(text);
-      if (value != null) return value;
-    }
     if (text != null) {
       const prefix = 'MessageStatus.';
       String valueName = text.startsWith(prefix) ? text.substring(prefix.length) : text;
@@ -259,7 +250,6 @@ class MessageStatus {
   const MessageStatus(this.name);
   String toString() => 'MessageStatus.$name';
 }
-MessageStatus Function(String text) MessageStatus_fromStringOverride;
 
 class SuggestedReply {
   static const collectionName = 'suggestedReplies';
@@ -362,10 +352,6 @@ class TagType {
   ];
 
   static TagType fromString(String text, [TagType defaultValue = TagType.Normal]) {
-    if (TagType_fromStringOverride != null) {
-      var value = TagType_fromStringOverride(text);
-      if (value != null) return value;
-    }
     if (text != null) {
       const prefix = 'TagType.';
       String valueName = text.startsWith(prefix) ? text.substring(prefix.length) : text;
@@ -381,7 +367,6 @@ class TagType {
   const TagType(this.name);
   String toString() => 'TagType.$name';
 }
-TagType Function(String text) TagType_fromStringOverride;
 
 class SystemMessage {
   static const collectionName = 'systemMessages';


### PR DESCRIPTION
This functionality is not used by nook and will not be part of the updated codegen