### PR TITLE
Add exclude filter and reuse shared code between filters

### DIFF
--- a/webapp/lib/controller_filter_helper.dart
+++ b/webapp/lib/controller_filter_helper.dart
@@ -1,0 +1,80 @@
+part of controller;
+
+enum TagFilterType {
+  include,
+  exclude,
+  lastInboundTurn
+}
+
+class ConversationFilter {
+  Map<TagFilterType, List<model.Tag>> filterTags;
+  Map<TagFilterType, DateTime> afterDateFilter;
+
+  ConversationFilter() {
+    filterTags = {
+      TagFilterType.include: [],
+      TagFilterType.exclude: [],
+      TagFilterType.lastInboundTurn: []
+    };
+    afterDateFilter = {
+      TagFilterType.include: null,
+      TagFilterType.exclude: null,
+    };
+  }
+
+  ConversationFilter.fromUrl() {
+    filterTags = {};
+    afterDateFilter = {};
+
+    // include filter
+    List<String> filterTagIds = view.urlView.getPageUrlFilterTags(TagFilterType.include);
+    print(filterTagIds);
+    filterTags[TagFilterType.include] = tagIdsToTags(filterTagIds, conversationTags).toList();
+
+    // exclude filter
+    filterTagIds = view.urlView.getPageUrlFilterTags(TagFilterType.exclude);
+    print(filterTagIds);
+    filterTags[TagFilterType.exclude] = tagIdsToTags(filterTagIds, conversationTags).toList();
+
+    // last inbound tags
+    filterTagIds = view.urlView.getPageUrlFilterTags(TagFilterType.lastInboundTurn);
+    print(filterTagIds);
+    filterTags[TagFilterType.lastInboundTurn] = tagIdsToTags(filterTagIds, messageTags).toList();
+
+    // after date filter
+    afterDateFilter[TagFilterType.include] = view.urlView.getPageUrlFilterAfterDate(TagFilterType.include);
+    afterDateFilter[TagFilterType.exclude] = view.urlView.getPageUrlFilterAfterDate(TagFilterType.exclude);
+  }
+
+  // bool contains(model.Tag tag) {
+  //   return includeTags.contains(tag) || excludeTags.contains(tag);
+  // }
+
+  bool get isEmpty => filterTags[TagFilterType.include].isEmpty
+                   && filterTags[TagFilterType.exclude].isEmpty
+                   && filterTags[TagFilterType.lastInboundTurn].isEmpty
+                   && afterDateFilter[TagFilterType.include] == null
+                   && afterDateFilter[TagFilterType.exclude] == null;
+
+  Set<String> get includeFilterTagIds => filterTags[TagFilterType.include].map<String>((tag) => tag.tagId).toSet();
+  Set<String> get excludeFilterTagIds => filterTags[TagFilterType.exclude].map<String>((tag) => tag.tagId).toSet();
+  Set<String> get lastInboundTurnFilterTagIds => filterTags[TagFilterType.lastInboundTurn].map<String>((tag) => tag.tagId).toSet();
+  Map<TagFilterType, Set<String>> get filterTagIds => {
+    TagFilterType.include: includeFilterTagIds,
+    TagFilterType.exclude: excludeFilterTagIds,
+    TagFilterType.lastInboundTurn: lastInboundTurnFilterTagIds
+  };
+
+  bool test(model.Conversation conversation) {
+    // Filter by the last (most recent) message
+    // TODO consider an option to filter by the first message
+    if (afterDateFilter[TagFilterType.include] != null && conversation.messages.last.datetime.isBefore(afterDateFilter[TagFilterType.include])) return false;
+    if (afterDateFilter[TagFilterType.exclude] != null && conversation.messages.last.datetime.isAfter(afterDateFilter[TagFilterType.exclude])) return false;
+
+    if (!conversation.tagIds.containsAll(includeFilterTagIds)) return false;
+    if (conversation.tagIds.intersection(excludeFilterTagIds).isNotEmpty) return false;
+    if (!conversation.lastInboundTurnTagIds.containsAll(lastInboundTurnFilterTagIds)) return false;
+
+    return true;
+  }
+}

--- a/webapp/lib/controller_filter_helper.dart
+++ b/webapp/lib/controller_filter_helper.dart
@@ -46,10 +46,6 @@ class ConversationFilter {
     afterDateFilter[TagFilterType.exclude] = view.urlView.getPageUrlFilterAfterDate(TagFilterType.exclude);
   }
 
-  // bool contains(model.Tag tag) {
-  //   return includeTags.contains(tag) || excludeTags.contains(tag);
-  // }
-
   bool get isEmpty => filterTags[TagFilterType.include].isEmpty
                    && filterTags[TagFilterType.exclude].isEmpty
                    && filterTags[TagFilterType.lastInboundTurn].isEmpty

--- a/webapp/lib/controller_view_helper.dart
+++ b/webapp/lib/controller_view_helper.dart
@@ -153,71 +153,38 @@ void _populateTagPanelView(List<model.Tag> tags, TagReceiver tagReceiver) {
   }
 }
 
-void _removeTagsFromFilterMenu(Map<String, List<model.Tag>> tagsByCategory) {
+void _removeTagsFromFilterMenu(Map<String, List<model.Tag>> tagsByCategory, TagFilterType filterType) {
   for (var category in tagsByCategory.keys.toList()..sort()) {
     for (var tag in tagsByCategory[category]) {
-      view.conversationFilter.removeMenuTag(new view.FilterMenuTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)), category);
+      view.conversationFilter[filterType].removeMenuTag(new view.FilterMenuTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type), filterType), category);
     }
   }
 }
 
-void _addTagsToFilterMenu(Map<String, List<model.Tag>> tagsByCategory) {
+void _addTagsToFilterMenu(Map<String, List<model.Tag>> tagsByCategory, TagFilterType filterType) {
   for (var category in tagsByCategory.keys.toList()..sort()) {
     for (var tag in tagsByCategory[category]) {
-      view.conversationFilter.addMenuTag(new view.FilterMenuTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)), category);
+      view.conversationFilter[filterType].addMenuTag(new view.FilterMenuTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type), filterType), category);
     }
   }
 }
 
-void _modifyTagsInFilterMenu(Map<String, List<model.Tag>> tagsByCategory) {
+void _modifyTagsInFilterMenu(Map<String, List<model.Tag>> tagsByCategory, TagFilterType filterType) {
   for (var category in tagsByCategory.keys.toList()..sort()) {
     for (var tag in tagsByCategory[category]) {
-      view.conversationFilter.modifyMenuTag(new view.FilterMenuTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)), category);
+      view.conversationFilter[filterType].modifyMenuTag(new view.FilterMenuTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type), filterType), category);
     }
   }
 }
 
-
-void _removeTagsFromFilterTurnsMenu(Map<String, List<model.Tag>> tagsByCategory) {
-  for (var category in tagsByCategory.keys.toList()..sort()) {
-    for (var tag in tagsByCategory[category]) {
-      view.conversationTurnsFilter.removeMenuTag(new view.FilterMenuTurnTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)), category);
-    }
-  }
+void _addDateTagToFilterMenu(TagFilterType filterType) {
+  view.conversationFilter[filterType].addMenuTag(view.AfterDateFilterMenuTagView(filterType), "Date");
 }
 
-void _addTagsToFilterTurnsMenu(Map<String, List<model.Tag>> tagsByCategory) {
-  for (var category in tagsByCategory.keys.toList()..sort()) {
-    for (var tag in tagsByCategory[category]) {
-      view.conversationTurnsFilter.addMenuTag(new view.FilterMenuTurnTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)), category);
-    }
-  }
-}
-
-void _modifyTagsInFilterTurnsMenu(Map<String, List<model.Tag>> tagsByCategory) {
-  for (var category in tagsByCategory.keys.toList()..sort()) {
-    for (var tag in tagsByCategory[category]) {
-      view.conversationTurnsFilter.modifyMenuTag(new view.FilterMenuTurnTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)), category);
-    }
-  }
-}
-
-
-void _addDateTagToFilterMenu() {
-  view.conversationFilter.addMenuTag(view.AfterDateFilterMenuTagView(), "Date");
-}
-
-void _populateSelectedFilterTags(List<model.Tag> tags) {
-  view.conversationFilter.clearSelectedTags();
+void _populateSelectedFilterTags(List<model.Tag> tags, TagFilterType filterType) {
+  view.conversationFilter[filterType].clearSelectedTags();
   for (var tag in tags) {
-    view.conversationFilter.addFilterTag(new view.FilterTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
-  }
-}
-
-void _populateSelectedFilterTurnTags(List<model.Tag> tags) {
-  view.conversationTurnsFilter.clearSelectedTags();
-  for (var tag in tags) {
-    view.conversationTurnsFilter.addFilterTag(new view.FilterTurnTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type)));
+    view.conversationFilter[filterType].addFilterTag(new view.FilterTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type), filterType));
   }
 }
 

--- a/webapp/web/styles.css
+++ b/webapp/web/styles.css
@@ -87,14 +87,18 @@ main {
     z-index: 5;
 }
 
-.tags-menu__box::before {
-    content: '';
-    width: 150px;
-    height: 100%;
-    background: white;
+.tags-menu__buttress {
+    width: 50px;
+    height: 30%;
     opacity: 0;
     position: absolute;
-    left: -150px;
+    left: -50px;
+    bottom: 0;
+    pointer-events: none;
+}
+
+.conversation-filter:hover .tags-menu__buttress path {
+    pointer-events: all;
 }
 
 .tags-menu__wrapper {


### PR DESCRIPTION
This is a big and messy change, sorry in advance...

Basically it brings back the exclude filter prototyped a while back ( #194 and #208). With quite a bit of the code needing to be shared between the (now) three filters, I took the earlier approach of grouping the filters in a class and differentiating between them via a `TagFilterType` enum (hence some of the more recent last inbound turn code being deleted).

The CSS changes are to make the management of the stacked filter menus better, by changing the hover border from a rectangle taking the whole left side of the menu to a triangle:
<img width="297" alt="Screenshot 2020-08-04 at 01 08 03" src="https://user-images.githubusercontent.com/1173973/89238773-243b7d80-d5ef-11ea-968f-b5342c32489c.png">

Re #189 (if this change feels ok to use, it might even close that issue!)

Thanks!