### PR TITLE
update model with new codegen

### DIFF
--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -135,7 +135,7 @@ class Conversation {
     tagIds = newTagIds;
     return pubSubClient.publishAddOpinion('nook_conversations/set_tags', {
       'conversation_id': docId,
-      'tags': tagIds,
+      'tags': tagIds.toList(),
     });
   }
 

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -74,7 +74,7 @@ class Conversation {
     return (modelObj ?? Conversation())
       ..demographicsInfo = Map_fromData<String>(data['demographicsInfo'], String_fromData)
       ..tagIds = Set_fromData<String>(data['tags'], String_fromData)
-      ..lastInboundTurnTagIds = Set_fromData<String>(data['lastInboundTurnTags'], String_fromData) ?? {} // it's optional
+      ..lastInboundTurnTagIds = Set_fromData<String>(data['lastInboundTurnTags'], String_fromData) ?? {}
       ..messages = List_fromData<Message>(data['messages'], Message.fromData)
       ..notes = String_fromData(data['notes'])
       ..unread = bool_fromData(data['unread']) ?? true;

--- a/webapp/lib/model.g.dart
+++ b/webapp/lib/model.g.dart
@@ -144,12 +144,11 @@ class Conversation {
   Future<void> removeTagIds(DocPubSubUpdate pubSubClient, Iterable<String> oldTagIds) {
     var toBeRemoved = Set<String>();
     for (var elem in oldTagIds) {
-      if (tagIds.contains(elem)) {
+      if (tagIds.remove(elem)) {
         toBeRemoved.add(elem);
       }
     }
     if (toBeRemoved.isEmpty) return Future.value(null);
-    tagIds.removeAll(toBeRemoved);
     return pubSubClient.publishAddOpinion('nook_conversations/remove_tags', {
       'conversation_id': docId,
       'tags': toBeRemoved.toList(),

--- a/webapp/lib/model.yaml
+++ b/webapp/lib/model.yaml
@@ -7,7 +7,7 @@ Conversation:
   namespace:              'nook_conversations'
   demographicsInfo: 'map string'
   tags: 'publishable set string tagIds'
-  lastInboundTurnTags: 'set string lastInboundTurnTagIds'
+  lastInboundTurnTags: 'set string lastInboundTurnTagIds, default {}'
   messages: 'array Message'
   notes: 'publishable string'
   unread: 'publishable bool, default true'

--- a/webapp/lib/model.yaml
+++ b/webapp/lib/model.yaml
@@ -10,11 +10,11 @@ Conversation:
   lastInboundTurnTags: 'set string lastInboundTurnTagIds'
   messages: 'array Message'
   notes: 'publishable string'
-  unread: 'publishable bool, true'
+  unread: 'publishable bool, default true'
 
 Message:
   firebaseDocId: 'none'
-  direction: 'MessageDirection, MessageDirection.Out'
+  direction: 'MessageDirection, default MessageDirection.Out'
   datetime: 'datetime'
   status: MessageStatus
   tags: 'array string tagIds'
@@ -50,10 +50,10 @@ SuggestedReply:
 Tag:
   firebaseDocId: 'string tagId'
   text: 'string'
-  type: 'TagType, TagType.Normal'
+  type: 'TagType, default TagType.Normal'
   shortcut: 'string'
   filterable: 'bool'
-  group: "string, ''"
+  group: "string, default ''"
 
 TagType:
   dartType: 'enum'
@@ -66,7 +66,7 @@ SystemMessage:
   firebaseCollectionName: 'systemMessages'
   firebaseDocId: 'string msgId'
   text: string
-  expired: 'bool, false'
+  expired: 'bool, default false'
 
 UserConfiguration:
   firebaseCollectionName: 'users'


### PR DESCRIPTION
This updates `model.yaml` to use the [updated codegen new spec](https://docs.google.com/document/d/1Jnr6TRjZFIlyw_pVXIwB58aGmUxkcWWYasOVt_jL42E/edit#heading=h.k4tz0qvvaa32) with built-in and custom validation options. To accomplish this, existing `*.yaml` files must be updated so that codegen can distinguish default values from validation options.

Other changes include:
* changed `model.yaml` to specify `{}` as the default for `lastInboundTurnTagIds` to match earlier manual code modification
* minor updates to codegen add to and remove from set operations