### PR TITLE
Decrease scroll height on item removal & use fixed min height when view is empty

### DIFF
--- a/webapp/lib/lazy_list_view_model.dart
+++ b/webapp/lib/lazy_list_view_model.dart
@@ -84,7 +84,11 @@ class LazyListViewModel {
   }
 
   void removeItem(LazyListViewItem item) {
+    int position = _items.indexOf(item);
     _items.remove(item);
+    if (position < _listView.children.length - 1) {
+      _scrollLength -= item.element.clientHeight;
+    }
     item.disposeElement();
     _scrollPad.remove();
     _updateScrollPad();
@@ -121,7 +125,7 @@ class LazyListViewModel {
   void _updateScrollPad() {
     _scrollPad.remove();
     int padHeight;
-    if (_listView.children.length < _items.length) {
+    if (_listView.children.length < _items.length && _listView.children.length != 0) {
       // Add a DOM element to pad the height of the scroll list
       // so that scrolling approximates the list size
       // without adding all of the individual DOM elements


### PR DESCRIPTION
It's a bit hard to describe the issue that @lukechurch was experiencing, but here we go: when using multiple filters and removing one, the view would remain empty or show only one element, even though the conversation list should have had 10s of elements. What seemed to be happening was that the `_scrollLength` would remain set to a previous old height, which was higher than the desired height in `_updateCachedElements`, so no new elements would be added to the view.

It seems that from #405 (keeping the selected conversations in view even if they don't meet the filters anymore) we're making more use than before of updating the conversation list in place, so it's doesn't get cleared up as often as before, which results in this issue being surfaced, even though it hasn't been introduced recently.