### PR TITLE
Add an optional --only flag to pass to firebase deploy

### DIFF
--- a/tool/deploy_webapp.sh
+++ b/tool/deploy_webapp.sh
@@ -5,6 +5,11 @@ WORK_DIR="$(pwd)"
 
 ########## parse and validate argument(s)
 
+usage_and_exit() {
+  echo "Usage: $0 [--skip-cloud-functions] [--only hosting|database|firestore] path/to/firebase/deployment/constants.json path/to/crypto/token/file"
+  exit 1
+}
+
 FIREBASE_DEPLOY_ARGS=()
 
 while [ "$#" -gt 0 ]; do
@@ -16,6 +21,10 @@ while [ "$#" -gt 0 ]; do
     --only)
       shift
       FIREBASE_DEPLOY_ARGS[0]="--only"
+      if [ -z "$1" ]; then
+        echo "expected a specific firebase service to deploy"
+        usage_and_exit
+      fi
       FIREBASE_DEPLOY_ARGS[1]="$1"
       shift
       ;;
@@ -27,14 +36,14 @@ while [ "$#" -gt 0 ]; do
 done
 
 if [ $# -ne 2 ]; then
-    echo "Usage: $0 [--skip-cloud-functions] [--only hosting|database|firestore] path/to/firebase/deployment/constants.json path/to/crypto/token/file"
-    exit 1
+  echo "expected 2 required arguments"
+  usage_and_exit
 fi
 
 FIREBASE_CONSTANTS="$1"
 if [ ! -f "$FIREBASE_CONSTANTS" ]; then
   echo "could not find FIREBASE_CONSTANTS: $FIREBASE_CONSTANTS"
-  exit 1
+  usage_and_exit
 fi
 
 cd "$(dirname "$FIREBASE_CONSTANTS")"
@@ -48,7 +57,7 @@ cd "$WORK_DIR"
 CRYPTO_TOKEN="$2"
 if [ ! -f "$CRYPTO_TOKEN" ]; then
   echo "could not find CRYPTO_TOKEN: $CRYPTO_TOKEN"
-  exit 1
+  usage_and_exit
 fi
 
 cd "$(dirname "$CRYPTO_TOKEN")"
@@ -72,7 +81,7 @@ echo "project id: $CRYPTO_TOKEN_PROJECT_ID"
 
 if [ "$FIREBASE_CONSTANTS_PROJECT_ID" != "$CRYPTO_TOKEN_PROJECT_ID" ]; then
   echo "the two project ids must match, check that you're deploying to the correct project"
-  exit 1
+  usage_and_exit
 fi
 
 ########## cd to the nook project directory and get the absolute path


### PR DESCRIPTION
This will help make Nook deployments faster by being able to specify that only hosting should be deployed (there's other options, but hosting will be most useful).

It will also make deployment to the SOM-CC project easier, as it has a different set of database access rules that we don't maintain in the repo, which have sometimes been accidentally overwritten on deployments.

Tested both with and without the flag in the latest round of Nook deployments.