### PR TITLE
Various tag filtering improvements

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -637,6 +637,7 @@ void conversationListSelected(String conversationListRoot) {
   conversationListSubscription = null;
   if (conversationListRoot == ConversationListData.NONE) {
     view.urlView.setPageUrlConversationList(null);
+    view.conversationListPanelView.totalConversations = 0;
     return;
   }
   view.urlView.setPageUrlConversationList(conversationListRoot);
@@ -666,6 +667,8 @@ void conversationListSelected(String conversationListRoot) {
       log.debug('New conversations, added: $added');
       log.debug('New conversations, modified: $modified');
       log.debug('New conversations, removed: $removed');
+
+      view.conversationListPanelView.totalConversations = conversations.length;
 
       updateMissingTagIds(conversations, conversationTags);
 

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -336,7 +336,11 @@ void initUI() {
   selectedConversationTagsGroup = '';
   selectedMessageTagsGroup = '';
   hideDemogsTags = true;
-  conversationFilter = new ConversationFilter();
+
+  // Get any filter tags from the url
+  conversationFilter = new ConversationFilter.fromUrl();
+  _populateSelectedFilterTags(conversationFilter.filterTags[TagFilterType.include], TagFilterType.include);
+  view.conversationIdFilter.filter = conversationFilter.conversationIdFilter;
 
   platform.listenForConversationTags(
     (added, modified, removed) {
@@ -383,6 +387,15 @@ void initUI() {
       if (actionObjectState == UIActionObject.conversation || actionObjectState == UIActionObject.loadingConversations) {
         view.tagPanelView.selectedGroup = selectedConversationTagsGroup;
         _populateTagPanelView(conversationTagsByGroup[selectedConversationTagsGroup], TagReceiver.Conversation);
+      }
+
+      // Re-read the conversation filter from the URL since we now have the names of the tags
+      conversationFilter = new ConversationFilter.fromUrl();
+      _populateSelectedFilterTags(conversationFilter.filterTags[TagFilterType.include], TagFilterType.include);
+
+      if (currentConfig.conversationalTurnsEnabled) {
+        _populateSelectedFilterTags(conversationFilter.filterTags[TagFilterType.exclude], TagFilterType.exclude);
+        _populateSelectedFilterTags(conversationFilter.filterTags[TagFilterType.lastInboundTurn], TagFilterType.lastInboundTurn);
       }
     }
   );
@@ -592,14 +605,18 @@ void applyConfiguration(model.UserConfiguration newConfig) {
       // only clear things up after we've received the config from the server
       conversationFilter.filterTags[TagFilterType.lastInboundTurn] = [];
       view.urlView.setPageUrlFilterTags(TagFilterType.lastInboundTurn, []);
+    } else {
+      _populateSelectedFilterTags(conversationFilter.filterTags[TagFilterType.lastInboundTurn], TagFilterType.lastInboundTurn);
     }
 
-    // exclude filtering temporary sharing the flag with last inbound turns
+    // exclude filtering is temporary sharing the flag with last inbound turns
     view.conversationFilter[TagFilterType.exclude].showFilter(newConfig.conversationalTurnsEnabled);
     if (oldConfig.conversationalTurnsEnabled != null && !newConfig.conversationalTurnsEnabled) {
       // only clear things up after we've received the config from the server
       conversationFilter.filterTags[TagFilterType.exclude] = [];
       view.urlView.setPageUrlFilterTags(TagFilterType.exclude, []);
+    } else {
+      _populateSelectedFilterTags(conversationFilter.filterTags[TagFilterType.exclude], TagFilterType.exclude);
     }
   }
 
@@ -683,16 +700,6 @@ void conversationListSelected(String conversationListRoot) {
       String activeConversationId = activeConversation?.docId;
       if (updatedIds.contains(activeConversationId)) {
         activeConversation = conversations.firstWhere((c) => c.docId == activeConversationId);
-      }
-
-      // Get any filter tags from the url
-      conversationFilter = new ConversationFilter.fromUrl();
-      _populateSelectedFilterTags(conversationFilter.filterTags[TagFilterType.include], TagFilterType.include);
-      view.conversationIdFilter.filter = conversationFilter.conversationIdFilter;
-
-      if (currentConfig.conversationalTurnsEnabled) {
-        _populateSelectedFilterTags(conversationFilter.filterTags[TagFilterType.exclude], TagFilterType.exclude);
-        _populateSelectedFilterTags(conversationFilter.filterTags[TagFilterType.lastInboundTurn], TagFilterType.lastInboundTurn);
       }
 
       updateFilteredAndSelectedConversationLists();
@@ -858,6 +865,7 @@ void command(UIAction action, Data data) {
       conversationFilter.filterTags[tagData.filterType].add(tag);
       view.urlView.setPageUrlFilterTags(tagData.filterType, conversationFilter.filterTagIds[tagData.filterType].toList());
       view.conversationFilter[tagData.filterType].addFilterTag(new view.FilterTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type), tagData.filterType));
+      if (actionObjectState == UIActionObject.loadingConversations) return;
       updateFilteredAndSelectedConversationLists();
       break;
     case UIAction.removeConversationTag:
@@ -884,6 +892,7 @@ void command(UIAction action, Data data) {
       conversationFilter.filterTags[tagData.filterType].removeWhere((t) => t.tagId == tag.tagId);
       view.urlView.setPageUrlFilterTags(tagData.filterType, conversationFilter.filterTagIds[tagData.filterType].toList());
       view.conversationFilter[tagData.filterType].removeFilterTag(tag.tagId);
+      if (actionObjectState == UIActionObject.loadingConversations) return;
       updateFilteredAndSelectedConversationLists();
       break;
     case UIAction.promptAfterDateFilter:
@@ -893,10 +902,12 @@ void command(UIAction action, Data data) {
     case UIAction.updateAfterDateFilter:
       AfterDateFilterData filterData = data;
       conversationFilter.afterDateFilter[filterData.filterType] = filterData.afterDateFilter;
-      view.conversationFilter[TagFilterType.include].removeFilterTag(filterData.tagId);
+      view.conversationFilter[filterData.filterType].removeFilterTag(filterData.tagId);
       if (filterData.afterDateFilter != null) {
         view.conversationFilter[filterData.filterType].addFilterTag(new view.AfterDateFilterTagView(filterData.afterDateFilter, filterData.filterType));
       }
+      view.urlView.setPageUrlFilterAfterDate(filterData.filterType, filterData.afterDateFilter);
+      if (actionObjectState == UIActionObject.loadingConversations) return;
       updateFilteredAndSelectedConversationLists();
       break;
     case UIAction.updateConversationIdFilter:

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -392,9 +392,11 @@ void initUI() {
       // Re-read the conversation filter from the URL since we now have the names of the tags
       conversationFilter = new ConversationFilter.fromUrl();
       _populateSelectedFilterTags(conversationFilter.filterTags[TagFilterType.include], TagFilterType.include);
+      _populateSelectedAfterDateFilterTag(conversationFilter.afterDateFilter[TagFilterType.include], TagFilterType.include);
 
       if (currentConfig.conversationalTurnsEnabled) {
         _populateSelectedFilterTags(conversationFilter.filterTags[TagFilterType.exclude], TagFilterType.exclude);
+        _populateSelectedAfterDateFilterTag(conversationFilter.afterDateFilter[TagFilterType.exclude], TagFilterType.exclude);
         _populateSelectedFilterTags(conversationFilter.filterTags[TagFilterType.lastInboundTurn], TagFilterType.lastInboundTurn);
       }
     }
@@ -617,6 +619,7 @@ void applyConfiguration(model.UserConfiguration newConfig) {
       view.urlView.setPageUrlFilterTags(TagFilterType.exclude, []);
     } else {
       _populateSelectedFilterTags(conversationFilter.filterTags[TagFilterType.exclude], TagFilterType.exclude);
+      _populateSelectedAfterDateFilterTag(conversationFilter.afterDateFilter[TagFilterType.exclude], TagFilterType.exclude);
     }
   }
 

--- a/webapp/lib/controller_view_helper.dart
+++ b/webapp/lib/controller_view_helper.dart
@@ -188,6 +188,13 @@ void _populateSelectedFilterTags(List<model.Tag> tags, TagFilterType filterType)
   }
 }
 
+void _populateSelectedAfterDateFilterTag(DateTime afterDateFilter, TagFilterType filterType) {
+  view.conversationFilter[filterType].removeFilterTag(view.AFTER_DATE_TAG_ID);
+  if (afterDateFilter != null) {
+    view.conversationFilter[filterType].addFilterTag(new view.AfterDateFilterTagView(afterDateFilter, filterType));
+  }
+}
+
 view.TagStyle tagTypeToStyle(model.TagType tagType) {
   switch (tagType) {
     case model.TagType.Important:

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -815,8 +815,8 @@ class ConversationListPanelView {
   Map<String, ConversationSummary> _phoneToConversations = {};
   ConversationSummary activeConversation;
 
-  num _totalConversations = 0;
-  void set totalConversations(num v) {
+  int _totalConversations = 0;
+  void set totalConversations(int v) {
     _totalConversations = v;
     _conversationPanelTitle.text = _conversationPanelTitleText;
   }

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -815,6 +815,13 @@ class ConversationListPanelView {
   Map<String, ConversationSummary> _phoneToConversations = {};
   ConversationSummary activeConversation;
 
+  num _totalConversations = 0;
+  void set totalConversations(num v) {
+    _totalConversations = v;
+    _conversationPanelTitle.text = _conversationPanelTitleText;
+  }
+  String get _conversationPanelTitleText => '${_phoneToConversations.length}/${_totalConversations} conversations';
+
   ConversationListPanelView() {
     conversationListPanel = new DivElement()
       ..classes.add('conversation-list-panel');
@@ -833,7 +840,7 @@ class ConversationListPanelView {
     _conversationPanelTitle = new DivElement()
       ..classes.add('panel-title')
       ..classes.add('conversation-list-header__title')
-      ..text = '0 conversations';
+      ..text = _conversationPanelTitleText;
     panelHeader.append(_conversationPanelTitle);
 
     _markUnread = MarkUnreadActionView();
@@ -896,7 +903,7 @@ class ConversationListPanelView {
     for (var conversation in conversationsToAdd) {
       _phoneToConversations[conversation.deidentifiedPhoneNumber] = conversation;
     }
-    _conversationPanelTitle.text = '${_phoneToConversations.length} conversations';
+    _conversationPanelTitle.text = _conversationPanelTitleText;
   }
 
   void addOrUpdateConversation(Conversation conversation) {
@@ -911,7 +918,7 @@ class ConversationListPanelView {
         conversation.unread);
     _conversationList.addItem(summary, null);
     _phoneToConversations[summary.deidentifiedPhoneNumber] = summary;
-    _conversationPanelTitle.text = '${_phoneToConversations.length} conversations';
+    _conversationPanelTitle.text = _conversationPanelTitleText;
   }
 
   void updateConversationSummary(ConversationSummary summary, Conversation conversation) {
@@ -937,7 +944,7 @@ class ConversationListPanelView {
   void clearConversationList() {
     _conversationList.clearItems();
     _phoneToConversations.clear();
-    _conversationPanelTitle.text = '${_phoneToConversations.length} conversations';
+    _conversationPanelTitle.text = _conversationPanelTitleText;
   }
 
   void markConversationRead(String deidentifiedPhoneNumber) {


### PR DESCRIPTION
* Selected filter tags will be loaded from the URL on the first load of Nook, even with no conversation was selected. They will temporarily appear as their tag ID in yellow, and then will be replaced by their name once the tags have been loaded.
* Fixes handling of after date filters - they are now written and read from the URL properly
* Changes the conversation list panel to say "X/N conversations" - useful when filtering to know the total number of conversations
* Doesn't call `updateFilteredAndSelectedConversationLists` when no conversation list is selected, and filter tags and being adjusted (this was causing the "Select list" message to be cleared)

Note: this PR was developed on top of #427 , it will need to be merged after that one, and the target branch changed to master.

