### PR TITLE
Remove specific version for webdev

### DIFF
--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -23,6 +23,6 @@ jobs:
     - name: Build Release
       run: |
         cd webapp
-        pub global activate webdev 2.5.9
+        pub global activate webdev
         export PATH="$PATH":"$HOME/.pub-cache/bin"
         webdev build


### PR DESCRIPTION
`webdev 2.6.1` was released a few days ago, and it removes the dependency on a dev version of `build_web_compilers`, so we no longer need to skip `2.6`