### PR TITLE
Fix single shard projects not loading any data

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -508,6 +508,9 @@ void initUI() {
       String conversationListRoot = urlConversationListRoot;
       if (urlConversationListRoot == null) {
         conversationListRoot = ConversationListData.NONE;
+        if (shards.length == 1) { // we have just one shard - select it and load the data
+          conversationListRoot = shards.first.conversationListRoot;
+        }
       } else if (shards.where((shard) => shard.conversationListRoot == urlConversationListRoot).isEmpty) {
         log.warning("Attempting to select shard ${conversationListRoot} that doesn't exist");
         conversationListRoot = ConversationListData.NONE;


### PR DESCRIPTION
This was caused by the previous PR #417 that removed the shard-selection logic from view (which treated single-shard selectors differently to multi-shards), but then I didn't introduce it back in the controller.