### PR TITLE
Performance improvements to conversation list filtering

### DIFF
--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -955,15 +955,18 @@ class ConversationListPanelView {
   }
 
   void updateConversationList(Set<Conversation> conversations) {
-    Set<String> uuidSets = Set<String>();
+    Set<String> conversationUuids = Set<String>();
     for (Conversation c in conversations) {
-      uuidSets.add(c.docId);
+      conversationUuids.add(c.docId);
     }
-    _phoneToConversations.removeWhere((String uuid, ConversationSummary summary) {
-      if (uuidSets.contains(uuid)) return false;
-      _conversationList.removeItem(summary);
-      return true;
-    });
+    List<ConversationSummary> conversationsToRemove = [];
+    for (var uuid in _phoneToConversations.keys) {
+      if (conversationUuids.contains(uuid)) continue;
+      conversationsToRemove.add(_phoneToConversations[uuid]);
+    }
+    _conversationList.removeItems(conversationsToRemove);
+    _phoneToConversations.removeWhere((key, value) => !conversationUuids.contains(key));
+
     List<ConversationSummary> conversationsToAdd = [];
     for (var conversation in conversations) {
       ConversationSummary summary = _phoneToConversations[conversation.docId];


### PR DESCRIPTION
Fixes https://github.com/larksystems/Katikati-Core/issues/218

Three main changes:

1. It turns out that calling `.clientHeight` on the individual elements is expensive as it triggers DOM reflow in order to compute it. Instead we can use the `scrollHeight` of the list container (with the scrollpad removed) to get the height of the current elements, and then approximately compute the number of elements to add to the view based on the average height of the existing ones. So less precise, but gives us better performance.

2. Add a method for removing a list of items, not just individual items.

3. Cache the UI elements rather than disposing them when they're removed from the UI when filtering. They will be disposed as expected when e.g. switching conversation lists.

Here is some performance data:

| action | before | after | change in # of conversations |
| --- | --- | --- | --- |
| add filter "demo selected" | 3,511ms | 2,420ms | 7k => 11 |
| remove filter | 649ms | 530ms | 11 => 7k |
| add filter "demo selected" | 4,196ms | 2,344ms | 7k => 11 |
| select conversation that doesn't have "about conv" tag | 287ms | 266ms | |
| remove filter | 670ms | 507ms | 11 => 7k |
| add filter "about conversation" | 4,177ms | 2,408ms | 7k => 1.5k |
| remove filter | 3,4184ms | 1,035ms | 1.5k => 7k, scroll to 1.5k |
| add filter "about conversation" | 93,015ms | 2,130ms | 7k => 1.5k + scroll to 1.5k |
| remove filter | 51,693ms | 790ms | 1.5k => 7k + scroll to 1.5k |
| add filter "demo selected" | 110,292ms | 2,380ms | 7k => 11 |
| select first conversation | 359ms | 123ms | |
| remove filter | 17,040ms | 442ms | 11 => 7k |

The biggest difference is after the first round of filtering, and in particular due to the scrolling over a large number of conversations, and triggering reflows (by calling `.clientWidth`) for each of them.

(I'm also wondering since it only takes a couple of seconds to scroll to 1.5k, whether it's worth testing the difference between having a lazy list vs loading/removing all of the conversation in bulk into the DOM on startup - but we should probably run that test this on an older/less powerful computer)

@danrubel - I know it's been a while since you wrote this code, but if there's anything I'm missing via these changes that the previous approach was trying to account for, please let me know!