### PR TITLE
Back link to the main config page from converse UI

### DIFF
--- a/webapp/lib/app/nook/view.dart
+++ b/webapp/lib/app/nook/view.dart
@@ -69,9 +69,15 @@ class NookPageView extends PageView {
       showNormalStatus('signed in: ${latestCommitHash.substring(0, 8)}...');
     }, onError: (_) { /* Do nothing */ });
 
+    var backPageLink = new Element.a()
+      ..classes.add('configuration-view__back-link')
+      ..text = 'Back to the main configuration page'
+      ..onClick.listen((event) => controller.routeToPage(Page.homepage));
+
     navHeaderView.navContent = new DivElement()
+      ..classes.add('nav-content__grid-wrapper')
       ..append(conversationListSelectView.panel)
-      ..append(new DivElement()..classes.add('flex-fill-gap'))
+      ..append(new DivElement()..append(backPageLink))     
       ..append(otherLoggedInUsers.loggedInUsers);
   }
 

--- a/webapp/web/configure/configuration.css
+++ b/webapp/web/configure/configuration.css
@@ -4,6 +4,7 @@
   max-width: 750px;
   margin: 0 auto;
   width: 750px;
+  padding: 12px;
 }
 
 .configuration-view__back-link {
@@ -23,7 +24,7 @@
 .configuration-view__title {
   font-size: large;
   font-weight: bold;
-  padding: 30px 0 30px;
+  padding: 30px 0 12px 0;
 }
 
 .configuration-actions {

--- a/webapp/web/converse/styles.css
+++ b/webapp/web/converse/styles.css
@@ -33,6 +33,11 @@ main {
     overflow: hidden;
 }
 
+.nav-content__grid-wrapper {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+}
+
 .conversation-list-panel,
 .conversation-panel,
 .reply-panel,

--- a/webapp/web/styles.css
+++ b/webapp/web/styles.css
@@ -45,6 +45,10 @@ header {
     padding: 8px;
 }
 
+.config-page-option__action {
+    width: 150px;
+}
+
 .config-page-option__action.config-page-option__action--disabled {
     background: #bbbbbb;
     pointer-events: none;


### PR DESCRIPTION
Ref: https://github.com/larksystems/Katikati-Core/issues/412

+ Moved the navbar to use grid so that the conversation selector, back to main config page, user presence can all co-exist
  - We may want to move the conversation selector to the top of conversations panel from the navbar

+ Minor clean up of spacing in the home page
  - The items under the title are closer to the its title than the neighbouring title
  - Buttons are of same width