### PR TITLE
Handle tag modification as removal and addition

### DIFF
--- a/webapp/lib/app/nook/controller.dart
+++ b/webapp/lib/app/nook/controller.dart
@@ -365,6 +365,8 @@ class NookController extends Controller {
 
     platform.listenForConversationTags(
       (added, modified, removed) {
+        var modifiedIds = modified.map((t) => t.tagId).toList();
+        var previousModified = conversationTags.where((tag) => modifiedIds.contains(tag.tagId)).toList();
         var updatedIds = new Set()
           ..addAll(added.map((t) => t.tagId))
           ..addAll(modified.map((t) => t.tagId))
@@ -380,12 +382,14 @@ class NookController extends Controller {
         filterTagsByCategory = _groupTagsIntoCategories(conversationTags);
 
         _removeTagsFromFilterMenu(_groupTagsIntoCategories(removed), TagFilterType.include);
+        _removeTagsFromFilterMenu(_groupTagsIntoCategories(previousModified), TagFilterType.include);
         _addTagsToFilterMenu(_groupTagsIntoCategories(added), TagFilterType.include);
-        _modifyTagsInFilterMenu(_groupTagsIntoCategories(modified), TagFilterType.include);
+        _addTagsToFilterMenu(_groupTagsIntoCategories(modified), TagFilterType.include);
 
         _removeTagsFromFilterMenu(_groupTagsIntoCategories(removed), TagFilterType.exclude);
+        _removeTagsFromFilterMenu(_groupTagsIntoCategories(previousModified), TagFilterType.exclude);
         _addTagsToFilterMenu(_groupTagsIntoCategories(added), TagFilterType.exclude);
-        _modifyTagsInFilterMenu(_groupTagsIntoCategories(modified), TagFilterType.exclude);
+        _addTagsToFilterMenu(_groupTagsIntoCategories(modified), TagFilterType.exclude);
 
         // Update the conversation tags by group map
         conversationTagsByGroup = _groupTagsIntoCategories(conversationTags);
@@ -424,6 +428,8 @@ class NookController extends Controller {
 
     platform.listenForMessageTags(
       (added, modified, removed) {
+        var modifiedIds = modified.map((t) => t.tagId).toList();
+        var previousModified = messageTags.where((tag) => modifiedIds.contains(tag.tagId)).toList();
         var updatedIds = new Set()
           ..addAll(added.map((t) => t.tagId))
           ..addAll(modified.map((t) => t.tagId))
@@ -437,8 +443,9 @@ class NookController extends Controller {
 
         filterLastInboundTurnTagsByCategory = _groupTagsIntoCategories(messageTags);
         _removeTagsFromFilterMenu(_groupTagsIntoCategories(removed), TagFilterType.lastInboundTurn);
+        _removeTagsFromFilterMenu(_groupTagsIntoCategories(previousModified), TagFilterType.lastInboundTurn);
         _addTagsToFilterMenu(_groupTagsIntoCategories(added), TagFilterType.lastInboundTurn);
-        _modifyTagsInFilterMenu(_groupTagsIntoCategories(modified), TagFilterType.lastInboundTurn);
+        _addTagsToFilterMenu(_groupTagsIntoCategories(modified), TagFilterType.lastInboundTurn);
 
         // Update the message tags by group map
         messageTagsByGroup = _groupTagsIntoCategories(messageTags);

--- a/webapp/lib/app/nook/controller_view_helper.dart
+++ b/webapp/lib/app/nook/controller_view_helper.dart
@@ -169,14 +169,6 @@ void _addTagsToFilterMenu(Map<String, List<model.Tag>> tagsByCategory, TagFilter
   }
 }
 
-void _modifyTagsInFilterMenu(Map<String, List<model.Tag>> tagsByCategory, TagFilterType filterType) {
-  for (var category in tagsByCategory.keys.toList()..sort()) {
-    for (var tag in tagsByCategory[category]) {
-      _view.conversationFilter[filterType].modifyMenuTag(new FilterMenuTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type), filterType), category);
-    }
-  }
-}
-
 void _addDateTagToFilterMenu(TagFilterType filterType) {
   _view.conversationFilter[filterType].addMenuTag(AfterDateFilterMenuTagView(filterType), "Date");
 }

--- a/webapp/lib/app/nook/view.dart
+++ b/webapp/lib/app/nook/view.dart
@@ -1146,14 +1146,6 @@ class ConversationFilter {
     _tagGroupsContainers[category].style.setProperty('grid-template-columns', 'repeat(auto-fill, ${columnWidth}px)');
   }
 
-  void modifyMenuTag(FilterMenuTagView tag, String category) {
-    int index = _tagGroups[category].indexWhere((t) => t.tag.dataset["id"] == tag.tag.dataset["id"]);
-    _tagGroups[category][index].tag.remove();
-    _tagGroups[category].removeAt(index);
-    _tagGroups[category].insert(index, tag);
-    _tagGroupsContainers[category].children.insert(index, tag.tag);
-  }
-
   void removeMenuTag(FilterMenuTagView tag, String category) {
     int index = _tagGroups[category].indexWhere((t) => t.tag.dataset["id"] == tag.tag.dataset["id"]);
     _tagGroups[category][index].tag.remove();


### PR DESCRIPTION
This allows better handling when the group of the tag changes, which currently fails with an "item not in list" error in view.dart on line 1150 as the previous group is lost, and the new group doesn't have that element.