### PR TITLE
update pubspec url

### DIFF
--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -28,10 +28,6 @@ jobs:
         #echo generating ssh key
         #ssh-keygen -t rsa -b 4096 -C "public@larksystems.com" -f $HOME/.ssh/id_rsa -N ''
 
-    - name: ssh test
-      run: |
-        ssh -vvvvvvvvvvvvv -T git@github.com
-
     - name: git clone test
       run: |
         mkdir -p ~/.pub-cache

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -17,9 +17,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd webapp
-        ls -alF ~/.pub-cache/
         pub get
     - name: Build Release
       run: |

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -15,23 +15,15 @@ jobs:
       with:
         sdk: 2.10.4
 
-    - name: setup ssh
+    - name: Setup ssh
       env:
-        SSH_KEY: ${{ secrets.KKBUILDPUBLIC_KEY }}
+        SSH_KEY: ${{ secrets.KK_PUBLIC_BUILD_SSH_KEY }}
       run: |
         echo HOME is $HOME
         mkdir -p $HOME/.ssh
         printf '%s\n' "$SSH_KEY" > $HOME/.ssh/id_rsa
         chmod u=rw,g=,o= $HOME/.ssh/id_rsa
         ls -alF $HOME/.ssh
-        # copy ssh key for valid github account ... public_build@larksystems.com
-        #echo generating ssh key
-        #ssh-keygen -t rsa -b 4096 -C "public@larksystems.com" -f $HOME/.ssh/id_rsa -N ''
-
-    - name: git clone test
-      run: |
-        mkdir -p ~/.pub-cache
-        git clone --mirror git@github.com:larksystems/katikati_ui_lib.dart.git $HOME/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -19,6 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         cd webapp
+        ls -alF ~/.ssh/
         pub get
     - name: Build Release
       run: |

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -22,7 +22,7 @@ jobs:
         echo HOME is $HOME
 
         mkdir -p $HOME/.ssh
-        #printf '%s\n' "$SSH_KEY" > $HOME/id_rsa
+        #printf '%s\n' "$SSH_KEY" > $HOME/.ssh/id_rsa
         echo generating ssh key
         ssh-keygen -t rsa -b 4096 -C "public@larksystems.com" -f $HOME/id_rsa -N ''
 

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -11,14 +11,13 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    container:
-      image: google/dart:2.10.4
-
     steps:
     - uses: actions/checkout@v2
+    - uses: dart-lang/setup-dart@v1
     - name: Install dependencies
       run: |
         cat /etc/ssh/ssh_config
+        echo HOME is $HOME
 
         echo known hosts
         mkdir -p ~/.ssh

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -22,6 +22,8 @@ jobs:
         echo HOME is $HOME
         mkdir -p $HOME/.ssh
         printf '%s\n' "$SSH_KEY" > $HOME/.ssh/id_rsa
+        chmod chmod u=rw,g=,o= $HOME/.ssh/id_rsa
+        ls -alF $HOME/.ssh
         # copy ssh key for valid github account ... public_build@larksystems.com
         #echo generating ssh key
         #ssh-keygen -t rsa -b 4096 -C "public@larksystems.com" -f $HOME/.ssh/id_rsa -N ''

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -18,8 +18,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
-        sudo ls -alF /root/.ssh
-        sudo cat /etc/ssh/ssh_config
+        cat /etc/ssh/ssh_config
 
         echo known hosts
         mkdir -p ~/.ssh

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        mkdir -p ~/.ssh
+        ssh-keyscan -H github.com >> ~/.ssh/known_hosts
         cd webapp
         pub get
     - name: Build Release

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -18,8 +18,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
-        ls -alF /root/.ssh
-        cat /etc/ssh/ssh_config
+        sudo ls -alF /root/.ssh
+        sudo cat /etc/ssh/ssh_config
 
         echo known hosts
         mkdir -p ~/.ssh

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -25,6 +25,10 @@ jobs:
         chmod u=rw,g=,o= $HOME/.ssh/id_rsa
         ls -alF $HOME/.ssh
 
+    - name: ssh test
+      run: |
+        ssh -vvvvvvvvvvvvv -T git@github.com
+
     - name: Install dependencies
       run: |
         cd webapp

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -22,8 +22,6 @@ jobs:
         ssh-keyscan -H github.com >> ~/.ssh/known_hosts
         mkdir -p ~/.pub-cache
         git clone --mirror git@github.com:larksystems/katikati_ui_lib.dart.git /github/home/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5
-        cd webapp
-        pub get
     - name: Build Release
       run: |
         cd webapp

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -12,10 +12,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: dart-lang/setup-dart@v1
+      with:
+        sdk: 2.10.4
 
     - name: Install dependencies
+      env:
+        SSH_KEY: ${{ secrets.PUBLIC_REPOS_SSH_KEY }}
       run: |
         echo HOME is $HOME
+        mkdir -p $HOME/.ssh
+        cat "$SSH_KEY" > $HOME/id_rsa
         echo git clone test
         mkdir -p ~/.pub-cache
         git clone --mirror git@github.com:larksystems/katikati_ui_lib.dart.git $HOME/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -20,6 +20,7 @@ jobs:
       run: |
         mkdir -p ~/.ssh
         ssh-keyscan github.com >> ~/.ssh/known_hosts
+        cat ~/.ssh/known_hosts
         mkdir -p ~/.pub-cache
         git clone --mirror git@github.com:larksystems/katikati_ui_lib.dart.git /github/home/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5
     - name: Build Release

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -24,7 +24,7 @@ jobs:
         mkdir -p $HOME/.ssh
         #printf '%s\n' "$SSH_KEY" > $HOME/.ssh/id_rsa
         echo generating ssh key
-        ssh-keygen -t rsa -b 4096 -C "public@larksystems.com" -f $HOME/id_rsa -N ''
+        ssh-keygen -t rsa -b 4096 -C "public@larksystems.com" -f $HOME/.ssh/id_rsa -N ''
 
         echo ssh test
         ssh -vvvvvvvvvvvvv -T git@github.com

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -20,10 +20,15 @@ jobs:
         SSH_KEY: ${{ secrets.PUBLIC_REPOS_SSH_KEY }}
       run: |
         echo HOME is $HOME
+
         mkdir -p $HOME/.ssh
         #printf '%s\n' "$SSH_KEY" > $HOME/id_rsa
         echo generating ssh key
         ssh-keygen -t rsa -b 4096 -C "public@larksystems.com" -f $HOME/id_rsa -N ''
+
+        echo ssh test
+        ssh -vvvvvvvvvvvvv -T git@github.com
+
         echo git clone test
         mkdir -p ~/.pub-cache
         git clone --mirror git@github.com:larksystems/katikati_ui_lib.dart.git $HOME/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -26,9 +26,6 @@ jobs:
         echo generating ssh key
         ssh-keygen -t rsa -b 4096 -C "public@larksystems.com" -f $HOME/.ssh/id_rsa -N ''
 
-        echo ssh test
-        ssh -vvvvvvvvvvvvv -T git@github.com
-
         echo git clone test
         mkdir -p ~/.pub-cache
         git clone --mirror git@github.com:larksystems/katikati_ui_lib.dart.git $HOME/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -21,7 +21,9 @@ jobs:
       run: |
         echo HOME is $HOME
         mkdir -p $HOME/.ssh
-        printf '%s\n' "$SSH_KEY" > $HOME/id_rsa
+        #printf '%s\n' "$SSH_KEY" > $HOME/id_rsa
+        echo generating ssh key
+        ssh-keygen -t rsa -b 4096 -C "public@larksystems.com" -f $HOME/id_rsa -N ''
         echo git clone test
         mkdir -p ~/.pub-cache
         git clone --mirror git@github.com:larksystems/katikati_ui_lib.dart.git $HOME/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -22,7 +22,7 @@ jobs:
         echo HOME is $HOME
         mkdir -p $HOME/.ssh
         printf '%s\n' "$SSH_KEY" > $HOME/.ssh/id_rsa
-        chmod chmod u=rw,g=,o= $HOME/.ssh/id_rsa
+        chmod u=rw,g=,o= $HOME/.ssh/id_rsa
         ls -alF $HOME/.ssh
         # copy ssh key for valid github account ... public_build@larksystems.com
         #echo generating ssh key

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -18,6 +18,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
+        ls -alF /root/.ssh
+        cat /etc/ssh/ssh_config
+
+        echo known hosts
         mkdir -p ~/.ssh
         ssh-keyscan github.com >> ~/.ssh/known_hosts
         cat ~/.ssh/known_hosts

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -20,6 +20,8 @@ jobs:
       run: |
         mkdir -p ~/.ssh
         ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+        mkdir -p ~/.pub-cache
+        git clone --mirror git@github.com:larksystems/katikati_ui_lib.dart.git /github/home/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5
         cd webapp
         pub get
     - name: Build Release

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -24,7 +24,7 @@ jobs:
         echo fingerprint
         ssh-keygen -lf ~/.ssh/known_hosts
         echo ssh test
-        ssh -o UserKnownHostsFile=~/.ssh/known_hosts -T git@github.com
+        ssh -o UserKnownHostsFile=~/.ssh/known_hosts -o StrictHostKeyChecking=no -T git@github.com
         mkdir -p ~/.pub-cache
         echo git clone test
         git clone --mirror git@github.com:larksystems/katikati_ui_lib.dart.git /github/home/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -21,7 +21,10 @@ jobs:
         mkdir -p ~/.ssh
         ssh-keyscan github.com >> ~/.ssh/known_hosts
         cat ~/.ssh/known_hosts
+        echo ssh test
+        ssh -o UserKnownHostsFile=~/.ssh/known_hosts -T git@github.com
         mkdir -p ~/.pub-cache
+        echo git clone test
         git clone --mirror git@github.com:larksystems/katikati_ui_lib.dart.git /github/home/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5
     - name: Build Release
       run: |

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -21,6 +21,8 @@ jobs:
         mkdir -p ~/.ssh
         ssh-keyscan github.com >> ~/.ssh/known_hosts
         cat ~/.ssh/known_hosts
+        echo fingerprint
+        ssh-keygen -lf ~/.ssh/known_hosts
         echo ssh test
         ssh -o UserKnownHostsFile=~/.ssh/known_hosts -T git@github.com
         mkdir -p ~/.pub-cache

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -21,12 +21,19 @@ jobs:
         mkdir -p ~/.ssh
         ssh-keyscan github.com >> ~/.ssh/known_hosts
         cat ~/.ssh/known_hosts
-        echo fingerprint
+        echo fingerprint 1
         ssh-keygen -lf ~/.ssh/known_hosts
+
         echo ssh test
+        set +e
         ssh -o UserKnownHostsFile=~/.ssh/known_hosts -o StrictHostKeyChecking=no -T git@github.com
-        mkdir -p ~/.pub-cache
+        set -e
+        cat ~/.ssh/known_hosts
+        echo fingerprint 2
+        ssh-keygen -lf ~/.ssh/known_hosts
+
         echo git clone test
+        mkdir -p ~/.pub-cache
         git clone --mirror git@github.com:larksystems/katikati_ui_lib.dart.git /github/home/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5
     - name: Build Release
       run: |

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -27,7 +27,7 @@ jobs:
         echo ssh test
         set +e
         #ssh -o UserKnownHostsFile=~/.ssh/known_hosts -o StrictHostKeyChecking=no -T git@github.com
-        ssh -vvvvvvvvvvvvv -T git@github.com
+        ssh -vvvvvvvvvvvvv -o UserKnownHostsFile=~/.ssh/known_hosts -T git@github.com
         set -e
         cat ~/.ssh/known_hosts
         echo fingerprint 2

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -15,25 +15,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-#        cat /etc/ssh/ssh_config
-#        echo HOME is $HOME
-#
-#        echo known hosts
-#        mkdir -p ~/.ssh
-#        ssh-keyscan github.com >> ~/.ssh/known_hosts
-#        cat ~/.ssh/known_hosts
-#        echo fingerprint 1
-#        ssh-keygen -lf ~/.ssh/known_hosts
-#
-#        echo ssh test
-#        set +e
-#        #ssh -o UserKnownHostsFile=~/.ssh/known_hosts -o StrictHostKeyChecking=no -T git@github.com
-#        ssh -vvvvvvvvvvvvv -o UserKnownHostsFile=~/.ssh/known_hosts -T git@github.com
-#        set -e
-#        cat ~/.ssh/known_hosts
-#        echo fingerprint 2
-#        ssh-keygen -lf ~/.ssh/known_hosts
-
+        echo HOME is $HOME
         echo git clone test
         mkdir -p ~/.pub-cache
         git clone --mirror git@github.com:larksystems/katikati_ui_lib.dart.git $HOME/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -21,7 +21,7 @@ jobs:
         mkdir -p ~/.ssh
         ssh-keyscan -H github.com >> ~/.ssh/known_hosts
         mkdir -p ~/.pub-cache
-        git clone --mirror git@github.com:larksystems/katikati_ui_lib.dart.git /github/home/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5
+        git clone --progress --verbose --mirror git@github.com:larksystems/katikati_ui_lib.dart.git /github/home/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5
     - name: Build Release
       run: |
         cd webapp

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -19,9 +19,9 @@ jobs:
     - name: Install dependencies
       run: |
         mkdir -p ~/.ssh
-        ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+        ssh-keyscan github.com >> ~/.ssh/known_hosts
         mkdir -p ~/.pub-cache
-        git clone --progress --verbose --mirror git@github.com:larksystems/katikati_ui_lib.dart.git /github/home/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5
+        git clone --mirror git@github.com:larksystems/katikati_ui_lib.dart.git /github/home/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5
     - name: Build Release
       run: |
         cd webapp

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -26,7 +26,8 @@ jobs:
 
         echo ssh test
         set +e
-        ssh -o UserKnownHostsFile=~/.ssh/known_hosts -o StrictHostKeyChecking=no -T git@github.com
+        #ssh -o UserKnownHostsFile=~/.ssh/known_hosts -o StrictHostKeyChecking=no -T git@github.com
+        ssh -vvvvvvvvvvvvv -T git@github.com
         set -e
         cat ~/.ssh/known_hosts
         echo fingerprint 2

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -25,10 +25,6 @@ jobs:
         chmod u=rw,g=,o= $HOME/.ssh/id_rsa
         ls -alF $HOME/.ssh
 
-    - name: ssh test
-      run: |
-        ssh -vvvvvvvvvvvvv -T git@github.com
-
     - name: Install dependencies
       run: |
         cd webapp

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         cd webapp
-        ls -alF ~/.ssh/
+        ls -alF ~/.pub-cache/
         pub get
     - name: Build Release
       run: |

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -36,7 +36,7 @@ jobs:
 
         echo git clone test
         mkdir -p ~/.pub-cache
-        git clone --mirror git@github.com:larksystems/katikati_ui_lib.dart.git /github/home/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5
+        git clone --mirror git@github.com:larksystems/katikati_ui_lib.dart.git $HOME/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5
 
     - name: Build Release
       run: |

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         echo HOME is $HOME
         mkdir -p $HOME/.ssh
-        cat "$SSH_KEY" > $HOME/id_rsa
+        printf '%s\n' "$SSH_KEY" > $HOME/id_rsa
         echo git clone test
         mkdir -p ~/.pub-cache
         git clone --mirror git@github.com:larksystems/katikati_ui_lib.dart.git $HOME/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -8,36 +8,36 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - uses: dart-lang/setup-dart@v1
+
     - name: Install dependencies
       run: |
-        cat /etc/ssh/ssh_config
-        echo HOME is $HOME
-
-        echo known hosts
-        mkdir -p ~/.ssh
-        ssh-keyscan github.com >> ~/.ssh/known_hosts
-        cat ~/.ssh/known_hosts
-        echo fingerprint 1
-        ssh-keygen -lf ~/.ssh/known_hosts
-
-        echo ssh test
-        set +e
-        #ssh -o UserKnownHostsFile=~/.ssh/known_hosts -o StrictHostKeyChecking=no -T git@github.com
-        ssh -vvvvvvvvvvvvv -o UserKnownHostsFile=~/.ssh/known_hosts -T git@github.com
-        set -e
-        cat ~/.ssh/known_hosts
-        echo fingerprint 2
-        ssh-keygen -lf ~/.ssh/known_hosts
+#        cat /etc/ssh/ssh_config
+#        echo HOME is $HOME
+#
+#        echo known hosts
+#        mkdir -p ~/.ssh
+#        ssh-keyscan github.com >> ~/.ssh/known_hosts
+#        cat ~/.ssh/known_hosts
+#        echo fingerprint 1
+#        ssh-keygen -lf ~/.ssh/known_hosts
+#
+#        echo ssh test
+#        set +e
+#        #ssh -o UserKnownHostsFile=~/.ssh/known_hosts -o StrictHostKeyChecking=no -T git@github.com
+#        ssh -vvvvvvvvvvvvv -o UserKnownHostsFile=~/.ssh/known_hosts -T git@github.com
+#        set -e
+#        cat ~/.ssh/known_hosts
+#        echo fingerprint 2
+#        ssh-keygen -lf ~/.ssh/known_hosts
 
         echo git clone test
         mkdir -p ~/.pub-cache
         git clone --mirror git@github.com:larksystems/katikati_ui_lib.dart.git /github/home/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5
+
     - name: Build Release
       run: |
         cd webapp

--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -15,20 +15,30 @@ jobs:
       with:
         sdk: 2.10.4
 
-    - name: Install dependencies
+    - name: setup ssh
       env:
-        SSH_KEY: ${{ secrets.PUBLIC_REPOS_SSH_KEY }}
+        SSH_KEY: ${{ secrets.KKBUILDPUBLIC_KEY }}
       run: |
         echo HOME is $HOME
-
         mkdir -p $HOME/.ssh
-        #printf '%s\n' "$SSH_KEY" > $HOME/.ssh/id_rsa
-        echo generating ssh key
-        ssh-keygen -t rsa -b 4096 -C "public@larksystems.com" -f $HOME/.ssh/id_rsa -N ''
+        printf '%s\n' "$SSH_KEY" > $HOME/.ssh/id_rsa
+        # copy ssh key for valid github account ... public_build@larksystems.com
+        #echo generating ssh key
+        #ssh-keygen -t rsa -b 4096 -C "public@larksystems.com" -f $HOME/.ssh/id_rsa -N ''
 
-        echo git clone test
+    - name: ssh test
+      run: |
+        ssh -vvvvvvvvvvvvv -T git@github.com
+
+    - name: git clone test
+      run: |
         mkdir -p ~/.pub-cache
         git clone --mirror git@github.com:larksystems/katikati_ui_lib.dart.git $HOME/.pub-cache/git/cache/katikati_ui_lib.dart-3bb29a7278798a4357cb8d178854b7206d1897e5
+
+    - name: Install dependencies
+      run: |
+        cd webapp
+        pub get
 
     - name: Build Release
       run: |

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Nook
-![Build Status](https://img.shields.io/github/workflow/status/larksystems/nook/Nook%20CI)
+![Build Status](https://github.com/larksystems/nook/actions/workflows/build_webapp.yml/badge.svg)

--- a/webapp/pubspec.yaml
+++ b/webapp/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   uuid: ^2.0.0
   katikati_ui_lib:
     git:
-      url: https://github.com/larksystems/katikati_ui_lib.dart.git
+      url: git@github.com:larksystems/katikati_ui_lib.dart.git
       ref: 588ad10003f318653026d50ce575e0afa67b5736
 
 dev_dependencies:


### PR DESCRIPTION
Several related changes:
* update the url in pubspec to use SSH rather than HTTPS
* update the Github CI to use the newer Dart Build and install an SSH key
* update the Github CI badge link in the README

If this looks good, I will pull together similar PRs for nook-configurator and katikati-reporting

cc @lukechurch 