### PR TITLE
Messages refactor

### DIFF
--- a/webapp/lib/app/configurator/view.dart
+++ b/webapp/lib/app/configurator/view.dart
@@ -42,6 +42,7 @@ class ConfigurationPageView extends PageView {
     renderElement.append(configurationActions);
 
     saveConfigurationButton = new ButtonElement()
+      ..disabled = true
       ..classes.add('configuration-actions__save-action')
       ..text = 'Save Configuration'
       ..onClick.listen((_) => controller.command(ConfigAction.saveConfiguration));
@@ -73,6 +74,19 @@ class ConfigurationPageView extends PageView {
     saveStatusElement.classes.toggle('hidden', true);
     // Remove the contents after the animation ends
     new Timer(new Duration(milliseconds: _ANIMATION_LENGTH_MS), () => saveStatusElement.text = '');
+  }
+
+  void enableSaveButton() {
+    saveConfigurationButton.removeAttribute('disabled');
+    configurationActions.classes.toggle('sticky', true);
+  }
+
+  void disableSaveButton() {
+    saveConfigurationButton.setAttribute('disabled', 'true');
+    new Timer(new Duration(milliseconds: 10 * _ANIMATION_LENGTH_MS), () {
+      saveStatusElement.text = '';
+      configurationActions.classes.toggle('sticky', false);
+    });
   }
 }
 

--- a/webapp/web/configure/buttons.css
+++ b/webapp/web/configure/buttons.css
@@ -1,8 +1,6 @@
 @charset "utf-8";
 
 .button {
-  display: inline-block;
-  align-self: center;
   vertical-align: middle;
   background-color: #fff;
   border-radius: 2px;
@@ -66,7 +64,6 @@
 .button--remove {
   width: 16px;
   height: 16px;
-  margin: 2px;
 }
 
 .button--remove:before,
@@ -109,7 +106,6 @@
 .button--add {
   width: 16px;
   height: 16px;
-  margin: 2px;
 }
 
 .button--add:before,
@@ -236,4 +232,18 @@
 .button--on-hover-red:active:before,
 .button--on-hover-red:active:after {
   background-color: #990000;
+}
+
+.button--fold-collapsed {
+  font-size: 10px;
+  height: 16px;
+  width: 16px;
+  border: none;
+  padding: 1px;
+  background-color: #fff;
+  cursor: pointer;
+}
+
+.button--fold-collapsed:hover {
+  background-color: #eee;
 }

--- a/webapp/web/configure/configuration.css
+++ b/webapp/web/configure/configuration.css
@@ -1,30 +1,39 @@
 .configuration-view {
-  display: flex;
-  flex-direction: column;
   max-width: 750px;
   margin: 0 auto;
   width: 750px;
+  padding: 15px 0 90px 0;
 }
 
 .configuration-view__title {
   font-size: large;
   font-weight: bold;
-  padding: 30px 0 30px;
+  padding: 30px 0 15px;
 }
 
 .configuration-actions {
-  display: flex;
-  margin: 20px 0;
-  align-items: center;
+  padding: 10px 0;
+  background-color: rgba(255, 255, 255, 0.8);
+}
+
+.configuration-actions.sticky {
+  position: sticky;
+  bottom: 0;
+  text-align: center;
+  margin-top: 15px;
+  border: 1px solid #dddddd;
 }
 
 .configuration-actions__save-action {
-  width: 130px;
-  height: 40px;
-  font-size: 1.1em;
+  padding: 10px 15px;
   background-color: #499398;
   color: #ffffff;
   border: none;
+}
+
+.configuration-actions__save-action:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
 }
 
 .configuration-actions__save-action__status {
@@ -45,15 +54,25 @@
 .standard-messages-group {
   position: relative;
   padding: 15px;
-  margin: 15px 0;
   border: 1px solid #ddd;
+  border-bottom: none;
+}
+
+.standard-messages-group:first-child {
+  margin-top: 15px;
+}
+
+.standard-messages-group:last-child {
+  border: 1px solid #ddd;
+  margin-bottom: 15px;
 }
 
 .standard-messages-group__title {
   font-weight: 600;
   display: inline-block;
-  padding: 0 1px;
-  margin-left: 10px;
+  padding: 0 6px;
+  min-width: 30px;
+  margin: 0 2px;
 }
 
 .standard-messages-group__title:empty:not(:focus):before {
@@ -64,46 +83,50 @@
 
 .standard-message {
   display: grid;
-  grid-template-columns: 47% 47% 3%;
-  grid-gap: 1.5%;
+  grid-template-columns: 1fr 1fr 16px;
+  grid-gap: 5px;
   position: relative;
+  margin-top: 15px;
 }
 
-.standard-message .button {
-  align-self: flex-start;
-  margin-top: 10px;
+.standard-messages-add__button {
+  margin-top: 15px;
 }
 
 .message {
-  display: grid;
-  margin: 10px 0;
+  position: relative;
 }
 
 .message__text {
   overflow-y: scroll;
   border: 1px solid #ddd;
-  border-radius: 2px;
-  padding: 2px;
-  min-height: 70px;
+  padding: 6px;
+  min-height: 96px;
   margin-bottom: 0px;
   width: 100%;
   font: inherit;
-  font-size: 0.9em;
   resize: none;
+  box-sizing: border-box;
+  vertical-align: top;
 }
 
 .message__text--alert {
   border-color: #fa8072;
   outline-color: #fa8072;
-  margin-bottom: 16px;
 }
 
 .message__length-indicator {
-  justify-self: flex-end;
-  font-size: 0.8em;
+  opacity: 0.5;
+  font-size: 0.7em;
+  text-align: right;
+  position: absolute;
+  bottom: 0;
+  right: 2px;
 }
 
 .message__length-indicator--alert {
+  opacity: 1;
   color: #fa8072;
   outline-color: #fa8072;
+  font-weight: bold;
 }

--- a/webapp/web/configure/modals.css
+++ b/webapp/web/configure/modals.css
@@ -2,10 +2,11 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
+  text-align: center;
   width: 100%;
   height: 100%;
   background: rgba(0, 0, 0, 0.33);
-  border-radius: 2px;
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
+ Made the design similar to the tags page
+ The collapse and expand works on the group level
+ Cleaned up layout to have standard padding, sizes
+ Save config floats over the messages when the form is dirty
+ When removing a message group, it expands to show all the messages that would be affected