### PR TITLE
Remove handling of separate message tags in Nook

### DIFF
--- a/webapp/lib/app/nook/controller_filter_helper.dart
+++ b/webapp/lib/app/nook/controller_filter_helper.dart
@@ -22,7 +22,7 @@ class ConversationFilter {
     filterTags = {
       TagFilterType.include: _getTagsFromUrl(TagFilterType.include, controller.conversationTagIdsToTags),
       TagFilterType.exclude: _getTagsFromUrl(TagFilterType.exclude, controller.conversationTagIdsToTags),
-      TagFilterType.lastInboundTurn: _getTagsFromUrl(TagFilterType.lastInboundTurn, controller.messageTagIdsToTags),
+      TagFilterType.lastInboundTurn: _getTagsFromUrl(TagFilterType.lastInboundTurn, controller.conversationTagIdsToTags),
     };
 
     afterDateFilter = {
@@ -61,10 +61,6 @@ class ConversationFilter {
     var unifierTagIds = tagsToTagIds(unifierTags).toSet();
     if (!unifierTagIds.containsAll(filterTagIds[TagFilterType.include])) return false;
     if (unifierTagIds.intersection(filterTagIds[TagFilterType.exclude]).isNotEmpty) return false;
-
-    tags = tagIdsToTags(conversation.lastInboundTurnTagIds, controller.messageTagIdsToTags);
-    unifierTags = tags.map((t) => unifierTagForTag(t, controller.messageTagIdsToTags));
-    unifierTagIds = tagsToTagIds(unifierTags).toSet();
     if (!unifierTagIds.containsAll(filterTagIds[TagFilterType.lastInboundTurn])) return false;
 
     if (!conversation.docId.startsWith(conversationIdFilter) && !conversation.shortDeidentifiedPhoneNumber.startsWith(conversationIdFilter)) return false;

--- a/webapp/lib/app/nook/controller_view_helper.dart
+++ b/webapp/lib/app/nook/controller_view_helper.dart
@@ -3,14 +3,8 @@ part of controller;
 const SEND_REPLY_BUTTON_TEXT = 'SEND';
 
 const TAG_CONVERSATION_BUTTON_TEXT = 'TAG';
-const TAG_MESSAGE_BUTTON_TEXT = 'TAG';
 
 const SMS_MAX_LENGTH = 160;
-
-enum TagReceiver {
-  Conversation,
-  Message
-}
 
 // Functions to populate the views with model objects.
 
@@ -62,7 +56,7 @@ void _updateConversationPanelView(model.Conversation conversation) {
 
 MessageView _generateMessageView(model.Message message, model.Conversation conversation) {
   List<TagView> tags = [];
-  for (var tag in tagIdsToTags(message.tagIds, controller.messageTagIdsToTags)) {
+  for (var tag in tagIdsToTags(message.tagIds, controller.conversationTagIdsToTags)) {
     bool shouldHighlightTag = controller.conversationFilter.filterTagIds[TagFilterType.include].contains(tag.tagId);
     shouldHighlightTag = shouldHighlightTag || controller.conversationFilter.filterTagIds[TagFilterType.lastInboundTurn].contains(tag.tagId);
     tags.add(new MessageTagView(tag.text, tag.tagId, tagTypeToStyle(tag.type), shouldHighlightTag));
@@ -106,17 +100,8 @@ void _populateReplyPanelView(List<model.SuggestedReply> replies) {
   }
 }
 
-void _populateTagPanelView(List<model.Tag> tags, TagReceiver tagReceiver) {
+void _populateTagPanelView(List<model.Tag> tags) {
   _view.tagPanelView.clear();
-  String buttonText = '';
-  switch (tagReceiver) {
-    case TagReceiver.Conversation:
-      buttonText = TAG_CONVERSATION_BUTTON_TEXT;
-      break;
-    case TagReceiver.Message:
-      buttonText = TAG_MESSAGE_BUTTON_TEXT;
-      break;
-  }
 
   // Important tags first, then sort by text string
   tags.sort((t1, t2) {
@@ -138,16 +123,9 @@ void _populateTagPanelView(List<model.Tag> tags, TagReceiver tagReceiver) {
   });
 
   for (var tag in tags) {
-    var tagView = new TagActionView(tag.text, tag.shortcut, tag.tagId, buttonText);
+    var tagView = new TagActionView(tag.text, tag.shortcut, tag.tagId, TAG_CONVERSATION_BUTTON_TEXT);
     tagView.showShortcut(controller.currentConfig.tagsKeyboardShortcutsEnabled);
-    switch (tagReceiver) {
-      case TagReceiver.Conversation:
-        tagView.showButtons(controller.currentConfig.tagConversationsEnabled);
-        break;
-      case TagReceiver.Message:
-        tagView.showButtons(controller.currentConfig.tagMessagesEnabled);
-        break;
-    }
+    tagView.showButtons(controller.currentConfig.tagConversationsEnabled);
     _view.tagPanelView.addTag(tagView);
   }
 }

--- a/webapp/lib/platform/platform.dart
+++ b/webapp/lib/platform/platform.dart
@@ -235,9 +235,6 @@ class Platform {
   void listenForConversationTags(TagCollectionListener listener, [OnErrorListener onErrorListener]) =>
       Tag.listen(_docStorage, listener, "/conversationTags", onErrorListener: onErrorListener);
 
-  void listenForMessageTags(TagCollectionListener listener, [OnErrorListener onErrorListener]) =>
-      Tag.listen(_docStorage, listener, "/messageTags", onErrorListener: onErrorListener);
-
   void listenForSuggestedReplies(SuggestedReplyCollectionListener listener, [OnErrorListener onErrorListener]) =>
       SuggestedReply.listen(_docStorage, listener, onErrorListener: onErrorListener);
 


### PR DESCRIPTION
First step towards https://github.com/larksystems/Katikati-Core/issues/496

Next step will be to rename `[...]conversationTags` as just `[...]tags`