### PR TITLE
Set the docker container version to use dart 2.10.4

### DIFF
--- a/.github/workflows/build_webapp.yml
+++ b/.github/workflows/build_webapp.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image:  google/dart:latest
+      image: google/dart:2.10.4
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The Github action fails because it pulls a dart 2.12 version