### PR TITLE
Add button for sorting the conversation list

### DIFF
--- a/webapp/lib/app/nook/controller.dart
+++ b/webapp/lib/app/nook/controller.dart
@@ -53,6 +53,7 @@ enum UIAction {
   deselectConversation,
   markConversationRead,
   markConversationUnread,
+  changeConversationSortOrder,
   selectMessage,
   deselectMessage,
   keyPressed,
@@ -68,6 +69,11 @@ enum UIAction {
   showSnackbar,
   updateConversationIdFilter,
   goToUser,
+}
+
+enum UIConversationSort {
+  mostRecentInMessageFirst,
+  alphabeticalById,
 }
 
 class MessageData extends Data {
@@ -294,6 +300,7 @@ NookPageView get _view => controller.view;
 
 class NookController extends Controller {
   UIActionObject actionObjectState = UIActionObject.loadingConversations;
+  UIConversationSort conversationSortOrder = UIConversationSort.mostRecentInMessageFirst;
 
   StreamSubscription conversationListSubscription;
   Set<model.Conversation> conversations;
@@ -335,8 +342,8 @@ class NookController extends Controller {
 
   @override
   void setUpOnLogin() {
-    conversations = emptyConversationsSet;
-    filteredConversations = emptyConversationsSet;
+    conversations = emptyConversationsSet(conversationSortOrder);
+    filteredConversations = emptyConversationsSet(conversationSortOrder);
     suggestedReplies = [];
     tags = [];
     tagIdsToTags = {};
@@ -728,6 +735,7 @@ class NookController extends Controller {
               ..lastInboundTurnTagIds = Set()
               ..notes = ""
               ..messages = []
+              ..suggestedMessages = []
               ..unread = false;
           } else {
             activeConversation = matches.first;
@@ -750,17 +758,21 @@ class NookController extends Controller {
         // Update the active conversation view as needed
         if (updatedIds.contains(activeConversation.docId)) {
           updateViewForConversation(activeConversation, updateInPlace: true);
-          if (!activeConversation.unread) {
-            command(UIAction.markConversationRead, ConversationData(activeConversation.docId));
-          }
         }
       },
       conversationListRoot,
       showAndLogError);
   }
 
-  SplayTreeSet<model.Conversation> get emptyConversationsSet =>
-      SplayTreeSet(model.ConversationUtil.mostRecentInboundFirst);
+  SplayTreeSet<model.Conversation> emptyConversationsSet(UIConversationSort sortOrder) {
+    switch (sortOrder) {
+      case UIConversationSort.alphabeticalById:
+        return SplayTreeSet(model.ConversationUtil.alphabeticalById);
+      case UIConversationSort.mostRecentInMessageFirst:
+      default:
+        return SplayTreeSet(model.ConversationUtil.mostRecentInboundFirst);
+    }
+  }
 
   model.UserConfiguration get baseUserConfiguration => new model.UserConfiguration()
       ..repliesKeyboardShortcutsEnabled = false
@@ -1062,6 +1074,15 @@ class NookController extends Controller {
         }
         platform.updateUnread(markedConversations, true).catchError(showAndLogError);
         break;
+      case UIAction.changeConversationSortOrder:
+        conversationSortOrder = UIConversationSort.values[(UIConversationSort.values.indexOf(conversationSortOrder) + 1) % UIConversationSort.values.length];
+        conversations = emptyConversationsSet(conversationSortOrder)
+          ..addAll(conversations);
+        filteredConversations = emptyConversationsSet(conversationSortOrder)
+          ..addAll(filteredConversations);
+        _view.conversationListPanelView.changeConversationSortOrder(conversationSortOrder);
+        updateFilteredAndSelectedConversationLists();
+        break;
       case UIAction.showConversation:
         ConversationData conversationData = data;
         if (conversationData.deidentifiedPhoneNumber == activeConversation.docId) break;
@@ -1073,8 +1094,8 @@ class NookController extends Controller {
         break;
       case UIAction.selectConversationList:
         ConversationListData conversationListData = data;
-        conversations = emptyConversationsSet;
-        filteredConversations = emptyConversationsSet;
+        conversations = emptyConversationsSet(conversationSortOrder);
+        filteredConversations = emptyConversationsSet(conversationSortOrder);
         selectedConversations.clear();
         activeConversation = null;
         actionObjectState = UIActionObject.loadingConversations;
@@ -1310,7 +1331,7 @@ class NookController extends Controller {
   void updateFilteredAndSelectedConversationLists() {
     filteredConversations = conversations.where((conversation) => conversationFilter.test(conversation)).toSet();
     if (!currentConfig.sendMultiMessageEnabled) {
-      activeConversation = updateViewForConversations(conversationsInView, updateList: true);
+      activeConversation = updateViewForConversations(conversationsInView);
       return;
     }
     // Update the conversation objects in [selectedConversations] in case any of them were replaced
@@ -1319,7 +1340,7 @@ class NookController extends Controller {
 
     // Show both filtered and selected conversations in the list,
     // but mark the selected conversations that don't meet the filter with a warning
-    activeConversation = updateViewForConversations(conversationsInView, updateList: true);
+    activeConversation = updateViewForConversations(conversationsInView);
     _view.conversationListPanelView.showCheckboxes(currentConfig.sendMultiMessageEnabled);
     conversationsInView.forEach((conversation) {
       if (selectedConversations.contains(conversation)) {
@@ -1336,9 +1357,9 @@ class NookController extends Controller {
   /// Shows the list of [conversations] and selects the first conversation
   /// where [updateList] is `true` if this list can be updated in place.
   /// Returns the first conversation in the list, or null if list is empty.
-  model.Conversation updateViewForConversations(Set<model.Conversation> conversations, {bool updateList = false}) {
+  model.Conversation updateViewForConversations(Set<model.Conversation> conversations) {
     // Update conversationListPanelView
-    _populateConversationListPanelView(conversations, updateList);
+    _populateConversationListPanelView(conversations);
 
     // Update conversationPanelView
     if (conversations.isEmpty) {

--- a/webapp/lib/app/nook/controller_view_helper.dart
+++ b/webapp/lib/app/nook/controller_view_helper.dart
@@ -11,12 +11,10 @@ const SMS_MAX_LENGTH = 160;
 
 // Functions to populate the views with model objects.
 
-void _populateConversationListPanelView(Set<model.Conversation> conversations, bool updateList) {
+void _populateConversationListPanelView(Set<model.Conversation> conversations) {
   _view.conversationListPanelView.hideLoadSpinner();
   _view.conversationListPanelView.hideSelectConversationListMessage();
-  if (conversations.isEmpty || !updateList) {
-    _view.conversationListPanelView.clearConversationList();
-  }
+  _view.conversationListPanelView.clearConversationList();
   _view.conversationListPanelView.updateConversationList(conversations);
 }
 

--- a/webapp/lib/app/nook/view.dart
+++ b/webapp/lib/app/nook/view.dart
@@ -15,6 +15,7 @@ import 'package:katikati_ui_lib/components/conversation/conversation_item.dart';
 import 'package:katikati_ui_lib/components/user_presence/user_presence_indicator.dart';
 import 'package:katikati_ui_lib/components/scroll_indicator/scroll_indicator.dart';
 import 'package:katikati_ui_lib/components/tag/tag.dart' as kk;
+import 'package:katikati_ui_lib/components/button/button.dart' as buttons;
 import 'package:nook/view.dart';
 import 'package:nook/app/utils.dart';
 
@@ -974,7 +975,7 @@ class ConversationListPanelView {
 
     _changeSortOrder = ChangeSortOrderActionView();
     panelHeader.append(new DivElement()
-      ..classes.add('conversation-list__sort-order')
+      ..classes.add('conversation-list-header__sort-order')
       ..append(_changeSortOrder.changeSortOrderAction));
 
     _loadSpinner = new DivElement()
@@ -1970,28 +1971,28 @@ class AddTagActionView extends AddActionView {
 class ChangeSortOrderActionView {
   DivElement changeSortOrderAction;
 
+  buttons.Button alphabetically;
+  buttons.Button chronologically;
+
   ChangeSortOrderActionView() {
     changeSortOrderAction = new DivElement()
       ..classes.add('sort-action__button')
       ..onClick.listen((_) => _view.appController.command(UIAction.changeConversationSortOrder));
-    showSortButton(UIConversationSort.alphabeticalById);
+
+    alphabetically = new buttons.Button(buttons.ButtonType("button--icon", iconClassName: "fas fa-sort-alpha-down"));
+    chronologically = new buttons.Button(buttons.ButtonType("button--icon", iconClassName: "fas fa-history"));
+
+    showSortButton(UIConversationSort.mostRecentInMessageFirst);
   }
 
   void showSortButton(UIConversationSort sort) {
-    changeSortOrderAction.classes.removeAll([
-      'sort-action__button--alphabetically',
-      'sort-action__button--chronologically',
-    ]);
+    changeSortOrderAction.children.clear();
     switch (sort) {
       case UIConversationSort.alphabeticalById:
-        changeSortOrderAction
-          ..title = 'Sort conversations alphabetically by ID'
-          ..classes.toggle('sort-action__button--alphabetically');
+        changeSortOrderAction.append(alphabetically.renderElement);
         break;
       case UIConversationSort.mostRecentInMessageFirst:
-        changeSortOrderAction
-          ..title = 'Sort conversations with most recent incoming message at the top'
-          ..classes.toggle('sort-action__button--chronologically');
+        changeSortOrderAction.append(chronologically.renderElement);
         break;
     }
   }

--- a/webapp/lib/app/nook/view.dart
+++ b/webapp/lib/app/nook/view.dart
@@ -51,7 +51,7 @@ class NookPageView extends PageView {
     tagPanelView = new TagPanelView();
     notesPanelView = new NotesPanelView();
     urlView = new UrlView();
-    
+
     tabsView = new TabsView([]);
 
     conversationFilter = {
@@ -71,16 +71,16 @@ class NookPageView extends PageView {
     var conversationListColumn = DivElement()..classes = ["nook-column-wrapper", "nook-column-wrapper--conversation-list"];
     var messagesViewColumn = DivElement()..classes = ["nook-column-wrapper", "nook-column-wrapper--messages-view"];
     var tabsViewColumn = DivElement()..classes = ["nook-column-wrapper", "nook-column-wrapper--tabs-view"];
-    
+
     mainElement
       ..append(conversationListColumn)
       ..append(messagesViewColumn)
       ..append(tabsViewColumn);
-    
+
     conversationListColumn.append(conversationListPanelView.conversationListPanel);
     messagesViewColumn.append(conversationPanelView.conversationPanel);
     tabsViewColumn.append(tabsView.renderElement);
-    
+
     bodyElement.append(snackbarView.snackbarElement);
 
     showNormalStatus('signed in');
@@ -977,6 +977,7 @@ class ConversationListSelectHeader {
 class ConversationListPanelView {
   DivElement conversationListPanel;
   SpanElement _conversationPanelTitle;
+  ChangeSortOrderActionView _changeSortOrder;
   LazyListViewModel _conversationList;
   CheckboxInputElement _selectAllCheckbox;
   DivElement _loadSpinner;
@@ -1017,6 +1018,11 @@ class ConversationListPanelView {
       ..classes.add('conversation-list-header__title')
       ..text = _conversationPanelTitleText;
     panelHeader.append(_conversationPanelTitle);
+
+    _changeSortOrder = ChangeSortOrderActionView();
+    panelHeader.append(new DivElement()
+      ..classes.add('conversation-list__sort-order')
+      ..append(_changeSortOrder.changeSortOrderAction));
 
     _loadSpinner = new DivElement()
       ..classes.add('load-spinner');
@@ -1138,6 +1144,10 @@ class ConversationListPanelView {
 
   void markConversationUnread(String deidentifiedPhoneNumber) {
     _phoneToConversations[deidentifiedPhoneNumber]?._markUnread();
+  }
+
+  void changeConversationSortOrder(UIConversationSort conversationSort) {
+    _changeSortOrder.showSortButton(conversationSort);
   }
 
   void checkConversation(String deidentifiedPhoneNumber) {
@@ -2003,5 +2013,35 @@ class AddTagActionView extends AddActionView {
     // No translation for tags
     _newActionTranslation.remove();
     _newActionTranslationLabel.remove();
+  }
+}
+
+class ChangeSortOrderActionView {
+  DivElement changeSortOrderAction;
+
+  ChangeSortOrderActionView() {
+    changeSortOrderAction = new DivElement()
+      ..classes.add('sort-action__button')
+      ..onClick.listen((_) => _view.appController.command(UIAction.changeConversationSortOrder));
+    showSortButton(UIConversationSort.alphabeticalById);
+  }
+
+  void showSortButton(UIConversationSort sort) {
+    changeSortOrderAction.classes.removeAll([
+      'sort-action__button--alphabetically',
+      'sort-action__button--chronologically',
+    ]);
+    switch (sort) {
+      case UIConversationSort.alphabeticalById:
+        changeSortOrderAction
+          ..title = 'Sort conversations alphabetically by ID'
+          ..classes.toggle('sort-action__button--alphabetically');
+        break;
+      case UIConversationSort.mostRecentInMessageFirst:
+        changeSortOrderAction
+          ..title = 'Sort conversations with most recent incoming message at the top'
+          ..classes.toggle('sort-action__button--chronologically');
+        break;
+    }
   }
 }

--- a/webapp/pubspec.lock
+++ b/webapp/pubspec.lock
@@ -263,11 +263,9 @@ packages:
   katikati_ui_lib:
     dependency: "direct main"
     description:
-      path: ui
-      ref: affdaddd1b0e8a75949add73185409ffbce458ed
-      resolved-ref: affdaddd1b0e8a75949add73185409ffbce458ed
-      url: "git@github.com:larksystems/katikati_common_lib.git"
-    source: git
+      path: "../../katikati_common_lib/ui"
+      relative: true
+    source: path
     version: "0.0.1"
   logging:
     dependency: transitive

--- a/webapp/pubspec.lock
+++ b/webapp/pubspec.lock
@@ -264,8 +264,8 @@ packages:
     dependency: "direct main"
     description:
       path: ui
-      ref: "54d8ecf1d265daadaaa17098529a33e0cbc9e2e2"
-      resolved-ref: "54d8ecf1d265daadaaa17098529a33e0cbc9e2e2"
+      ref: c867320710e972e638a46947c88763f4e9af0e3d
+      resolved-ref: c867320710e972e638a46947c88763f4e9af0e3d
       url: "git@github.com:larksystems/katikati_common_lib.git"
     source: git
     version: "0.0.1"

--- a/webapp/pubspec.lock
+++ b/webapp/pubspec.lock
@@ -263,9 +263,11 @@ packages:
   katikati_ui_lib:
     dependency: "direct main"
     description:
-      path: "../../katikati_common_lib/ui"
-      relative: true
-    source: path
+      path: ui
+      ref: "54d8ecf1d265daadaaa17098529a33e0cbc9e2e2"
+      resolved-ref: "54d8ecf1d265daadaaa17098529a33e0cbc9e2e2"
+      url: "git@github.com:larksystems/katikati_common_lib.git"
+    source: git
     version: "0.0.1"
   logging:
     dependency: transitive

--- a/webapp/pubspec.yaml
+++ b/webapp/pubspec.yaml
@@ -10,11 +10,10 @@ dependencies:
   intl: ^0.16.0
   uuid: ^2.0.0
   katikati_ui_lib:
-    path: ../../katikati_common_lib/ui
-    # git:
-    #   url: git@github.com:larksystems/katikati_common_lib.git
-    #   path: ui
-    #   ref: affdaddd1b0e8a75949add73185409ffbce458ed
+    git:
+      url: git@github.com:larksystems/katikati_common_lib.git
+      path: ui
+      ref: 54d8ecf1d265daadaaa17098529a33e0cbc9e2e2
 
 dev_dependencies:
   build_runner: ^1.7.0

--- a/webapp/pubspec.yaml
+++ b/webapp/pubspec.yaml
@@ -10,10 +10,11 @@ dependencies:
   intl: ^0.16.0
   uuid: ^2.0.0
   katikati_ui_lib:
-    git:
-      url: git@github.com:larksystems/katikati_common_lib.git
-      path: ui
-      ref: affdaddd1b0e8a75949add73185409ffbce458ed
+    path: ../../katikati_common_lib/ui
+    # git:
+    #   url: git@github.com:larksystems/katikati_common_lib.git
+    #   path: ui
+    #   ref: affdaddd1b0e8a75949add73185409ffbce458ed
 
 dev_dependencies:
   build_runner: ^1.7.0

--- a/webapp/pubspec.yaml
+++ b/webapp/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     git:
       url: git@github.com:larksystems/katikati_common_lib.git
       path: ui
-      ref: 54d8ecf1d265daadaaa17098529a33e0cbc9e2e2
+      ref: c867320710e972e638a46947c88763f4e9af0e3d
 
 dev_dependencies:
   build_runner: ^1.7.0

--- a/webapp/web/converse/index.html
+++ b/webapp/web/converse/index.html
@@ -25,6 +25,7 @@
   <link rel="stylesheet" type="text/css" href="/packages/katikati_ui_lib/components/scroll_indicator/scroll_indicator.css">
   <link rel="stylesheet" type="text/css" href="/packages/katikati_ui_lib/components/tabs/tabs.css">
   <link rel="stylesheet" type="text/css" href="/packages/katikati_ui_lib/components/tag/tag.css">
+  <link rel="stylesheet" type="text/css" href="/packages/katikati_ui_lib/components/button/button.css">
 
   <script src="https://www.gstatic.com/firebasejs/7.2.0/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/7.2.0/firebase-firestore.js"></script>

--- a/webapp/web/converse/styles.css
+++ b/webapp/web/converse/styles.css
@@ -204,6 +204,10 @@ main {
     margin: 0 16px 0 0;
 }
 
+.conversation-list-header__sort-order {
+    float: right;
+}
+
 .select-conversation-list-message {
     margin: auto;
     padding-top: 50px;


### PR DESCRIPTION
The conversation list can now be sorted:
* alphabetically by conversation ID
* by the timestamp of the last incoming message

Also makes the sorting of the conversation list live - ie. it will be updated on each new incoming message

Closes https://github.com/larksystems/Katikati-Core/issues/524

Note to self: dependent on https://github.com/larksystems/katikati_common_lib/pull/52 so that one needs to be merged first and then the pubspec files here need to be updated with the merge SHA