### PR TITLE
remove tag group references

### DIFF
--- a/webapp/lib/app/configurator/tags/controller_tag_helper.dart
+++ b/webapp/lib/app/configurator/tags/controller_tag_helper.dart
@@ -56,7 +56,7 @@ class TagManager {
       }
 
       if (tag.groups.isEmpty) {
-        _tagsByGroup.putIfAbsent(tag.group, () => []).add(tag);
+        _tagsByGroup.putIfAbsent('', () => []).add(tag);
         continue;
       }
       for (var group in tag.groups) {
@@ -111,7 +111,7 @@ class TagManager {
       removed.add(tag);
 
       if (oldTag.groups.isEmpty) {
-        _tagsByGroup[oldTag.group].remove(oldTag);
+        _tagsByGroup[''].remove(oldTag);
         continue;
       }
       for (var group in oldTag.groups) {

--- a/webapp/lib/app/configurator/tags/controller_view_helper.dart
+++ b/webapp/lib/app/configurator/tags/controller_view_helper.dart
@@ -45,11 +45,7 @@ Map<String, List<model.Tag>> _groupTagsIntoCategories(List<model.Tag> tags) {
   Map<String, List<model.Tag>> result = {};
   for (model.Tag tag in tags) {
     if (tag.groups.isEmpty) {
-      if (tag.group.isEmpty) {
-        result.putIfAbsent("", () => []).add(tag);
-        continue;
-      }
-      result.putIfAbsent(tag.group, () => []).add(tag);
+      result.putIfAbsent("", () => []).add(tag);
       continue;
     }
     for (var group in tag.groups) {

--- a/webapp/lib/app/nook/controller.dart
+++ b/webapp/lib/app/nook/controller.dart
@@ -1569,13 +1569,13 @@ class NookController extends Controller {
       var groupsToUpdate = <String>{};
       for (var tag in tagsToRemove) {
         if (tag.groups.isEmpty) {
-          groupsToUpdate.add(tag.group);
+          groupsToUpdate.add('');
           continue;
         }
         groupsToUpdate.addAll(tag.groups);
       }
       for (var group in groupsToUpdate) {
-        var tagsToRemoveForGroup = tagsToRemove.where((t) => t.groups.contains(group) || t.group == group).toList();
+        var tagsToRemoveForGroup = tagsToRemove.where((t) => t.groups.contains(group)).toList();
         for (var filterType in filterTypes) {
           _removeTagsFromFilterMenu({group: tagsToRemoveForGroup}, filterType);
         }
@@ -1589,13 +1589,13 @@ class NookController extends Controller {
     var groupsToUpdate = <String>{};
     for (var tag in tagsToAdd) {
       if (tag.groups.isEmpty) {
-        groupsToUpdate.add(tag.group);
+        groupsToUpdate.add('');
         continue;
       }
       groupsToUpdate.addAll(tag.groups);
     }
     for (var group in groupsToUpdate) {
-      var tagsToAddForGroup = tagsToAdd.where((t) => t.groups.contains(group) || t.group == group).toList();
+      var tagsToAddForGroup = tagsToAdd.where((t) => t.groups.contains(group)).toList();
       for (var filterType in filterTypes) {
         _addTagsToFilterMenu({group: tagsToAddForGroup}, filterType);
       }

--- a/webapp/lib/app/nook/controller_view_helper.dart
+++ b/webapp/lib/app/nook/controller_view_helper.dart
@@ -240,11 +240,7 @@ Map<String, List<model.Tag>> _groupTagsIntoCategories(List<model.Tag> tags) {
   Map<String, List<model.Tag>> result = {};
   for (model.Tag tag in tags) {
     if (tag.groups.isEmpty) {
-      if (tag.group.isEmpty) {
-        result.putIfAbsent("", () => []).add(tag);
-        continue;
-      }
-      result.putIfAbsent(tag.group, () => []).add(tag);
+      result.putIfAbsent("", () => []).add(tag);
       continue;
     }
     for (var group in tag.groups) {


### PR DESCRIPTION
This removes references to the deprecated `Tag.group` field.

I've tested this to the best of my ability in an attempt to ensure no exceptions and no functional changes,
but please review with a critical eye.