### PR TITLE
Various improvements to mandatory filtering

### DIFF
--- a/webapp/lib/app/nook/controller.dart
+++ b/webapp/lib/app/nook/controller.dart
@@ -624,6 +624,7 @@ class NookController extends Controller {
           _populateSelectedFilterTags(conversationFilter.getFilters(TagFilterType.include), TagFilterType.include);
           _populateSelectedFilterTags(conversationFilter.getFilters(TagFilterType.exclude), TagFilterType.exclude);
 
+          updateFilteredAndSelectedConversationLists();
         }
 
     if (oldConfig.conversationalTurnsEnabled != newConfig.conversationalTurnsEnabled) {
@@ -632,7 +633,7 @@ class NookController extends Controller {
         // only clear things up after we've received the config from the server
         conversationFilter.clearFilters(TagFilterType.lastInboundTurn);
 
-        _view.urlView.setPageUrlFilterTags(TagFilterType.lastInboundTurn, conversationFilter.filterTagIds[TagFilterType.lastInboundTurn]);
+        _view.urlView.setPageUrlFilterTags(TagFilterType.lastInboundTurn, conversationFilter.filterTagIdsManuallySet[TagFilterType.lastInboundTurn]);
       } else {
         _populateSelectedFilterTags(conversationFilter.getFilters(TagFilterType.lastInboundTurn), TagFilterType.lastInboundTurn);
       }
@@ -643,7 +644,7 @@ class NookController extends Controller {
         // only clear things up after we've received the config from the server
         conversationFilter.clearFilters(TagFilterType.exclude);
 
-        _view.urlView.setPageUrlFilterTags(TagFilterType.exclude, conversationFilter.filterTagIds[TagFilterType.exclude]);
+        _view.urlView.setPageUrlFilterTags(TagFilterType.exclude, conversationFilter.filterTagIdsManuallySet[TagFilterType.exclude]);
       } else {
         _populateSelectedFilterTags(conversationFilter.getFilters(TagFilterType.exclude), TagFilterType.exclude);
       }
@@ -953,7 +954,7 @@ class NookController extends Controller {
         model.Tag unifierTag = unifierTagForTag(tag, tagIdsToTags);
         var added = conversationFilter.addFilter(tagData.filterType, unifierTag);
         if (!added) return; // No change, nothing further to do
-        _view.urlView.setPageUrlFilterTags(tagData.filterType, conversationFilter.filterTagIds[tagData.filterType]);
+        _view.urlView.setPageUrlFilterTags(tagData.filterType, conversationFilter.filterTagIdsManuallySet[tagData.filterType]);
         _view.conversationFilter[tagData.filterType].addFilterTag(new FilterTagView(unifierTag.text, unifierTag.tagId, tagTypeToKKStyle(unifierTag.type), tagData.filterType));
         if (actionObjectState == UIActionObject.loadingConversations) return;
         updateFilteredAndSelectedConversationLists();
@@ -1006,7 +1007,7 @@ class NookController extends Controller {
         model.Tag tag = tagIdToTag(tagData.tagId, tagIdsToTags);
         var changed = conversationFilter.removeFilter(tagData.filterType, tag);
         if (!changed) return; // No change, nothing further to do
-        _view.urlView.setPageUrlFilterTags(tagData.filterType, conversationFilter.filterTagIds[tagData.filterType]);
+        _view.urlView.setPageUrlFilterTags(tagData.filterType, conversationFilter.filterTagIdsManuallySet[tagData.filterType]);
         _view.conversationFilter[tagData.filterType].removeFilterTag(tag.tagId);
         if (actionObjectState == UIActionObject.loadingConversations) return;
         updateFilteredAndSelectedConversationLists();

--- a/webapp/lib/app/nook/controller_filter_helper.dart
+++ b/webapp/lib/app/nook/controller_filter_helper.dart
@@ -5,48 +5,43 @@ class ConversationFilter {
   model.UserConfiguration userConfig;
   String conversationIdFilter;
 
-  Set<model.Tag> getFilters(TagFilterType typ) {
-    return _filterTags[typ].toSet();
+  Set<model.Tag> getFilters(TagFilterType type) {
+    return _filterTags[type].toSet();
   }
 
-  bool addFilter(TagFilterType typ, model.Tag tag) {
-    var previous = _filterTags[typ].toSet();
-    _filterTags[typ].add(tag);
+  bool addFilter(TagFilterType type, model.Tag tag) {
+    var previous = _filterTags[type].toSet();
+    _filterTags[type].add(tag);
     _applyMandatoryFilters();
-    var updated = _filterTags[typ];
+    var updated = _filterTags[type];
     // Dart doesn't seem to have a set equality test, test for same lengths and same elements
-    bool isChanged = !(updated.length == previous.length &&
-        updated.every((e) => previous.contains(e)));
+    bool isChanged = !(updated.length == previous.length && updated.every((e) => previous.contains(e)));
     return isChanged;
   }
 
-  bool removeFilter(TagFilterType typ, model.Tag tag) {
-    var previous = _filterTags[typ].toSet();
-    _filterTags[typ].remove(tag);
+  bool removeFilter(TagFilterType type, model.Tag tag) {
+    var previous = _filterTags[type].toSet();
+    _filterTags[type].remove(tag);
     _applyMandatoryFilters();
-    var updated = _filterTags[typ];
+    var updated = _filterTags[type];
     // Dart doesn't seem to have a set equality test, test for same lengths and same elements
-    bool isChanged = !(updated.length == previous.length &&
-        updated.every((e) => previous.contains(e)));
+    bool isChanged = !(updated.length == previous.length && updated.every((e) => previous.contains(e)));
     return isChanged;
   }
 
-  void clearFilters(TagFilterType typ) {
-    _filterTags[typ].clear();
+  void clearFilters(TagFilterType type) {
+    _filterTags[type].clear();
     _applyMandatoryFilters();
   }
 
   void updateUserConfig(model.UserConfiguration userConfig) {
+    _removeMandatoryFilters();
     this.userConfig = userConfig;
     _applyMandatoryFilters();
   }
 
   ConversationFilter(model.UserConfiguration userConfig) {
-    _filterTags = {
-      TagFilterType.include: Set(),
-      TagFilterType.exclude: Set(),
-      TagFilterType.lastInboundTurn: Set()
-    };
+    _filterTags = {TagFilterType.include: Set(), TagFilterType.exclude: Set(), TagFilterType.lastInboundTurn: Set()};
 
     updateUserConfig(userConfig);
     _applyMandatoryFilters();
@@ -55,12 +50,9 @@ class ConversationFilter {
 
   ConversationFilter.fromUrl(model.UserConfiguration userConfig) {
     _filterTags = {
-      TagFilterType.include:
-          _getTagsFromUrl(TagFilterType.include, controller.tagIdsToTags),
-      TagFilterType.exclude:
-          _getTagsFromUrl(TagFilterType.exclude, controller.tagIdsToTags),
-      TagFilterType.lastInboundTurn: _getTagsFromUrl(
-          TagFilterType.lastInboundTurn, controller.tagIdsToTags),
+      TagFilterType.include: _getTagsFromUrl(TagFilterType.include, controller.tagIdsToTags),
+      TagFilterType.exclude: _getTagsFromUrl(TagFilterType.exclude, controller.tagIdsToTags),
+      TagFilterType.lastInboundTurn: _getTagsFromUrl(TagFilterType.lastInboundTurn, controller.tagIdsToTags),
     };
     updateUserConfig(userConfig);
     _applyMandatoryFilters();
@@ -74,49 +66,53 @@ class ConversationFilter {
       _filterTags[TagFilterType.lastInboundTurn].isEmpty &&
       conversationIdFilter == "";
 
-  Map<TagFilterType, Set<String>> get filterTagIds => {
-        TagFilterType.include:
-            tagsToTagIds(_filterTags[TagFilterType.include]).toSet(),
-        TagFilterType.exclude:
-            tagsToTagIds(_filterTags[TagFilterType.exclude]).toSet(),
-        TagFilterType.lastInboundTurn:
-            tagsToTagIds(_filterTags[TagFilterType.lastInboundTurn]).toSet()
+  Map<TagFilterType, Set<String>> get filterTagIdsAll => {
+        TagFilterType.include: tagsToTagIds(_filterTags[TagFilterType.include]).toSet(),
+        TagFilterType.exclude: tagsToTagIds(_filterTags[TagFilterType.exclude]).toSet(),
+        TagFilterType.lastInboundTurn: tagsToTagIds(_filterTags[TagFilterType.lastInboundTurn]).toSet()
+      };
+
+  Map<TagFilterType, Set<String>> get filterTagIdsManuallySet => {
+        TagFilterType.include: tagsToTagIds(_filterTags[TagFilterType.include]).toSet()..removeWhere((tagId) => userConfig.mandatoryIncludeTagIds.contains(tagId)),
+        TagFilterType.exclude: tagsToTagIds(_filterTags[TagFilterType.exclude]).toSet()..removeWhere((tagId) => userConfig.mandatoryExcludeTagIds.contains(tagId)),
+        TagFilterType.lastInboundTurn: tagsToTagIds(_filterTags[TagFilterType.lastInboundTurn]).toSet()
       };
 
   bool test(model.Conversation conversation) {
-    var tags =
-        convertTagIdsToTags(conversation.tagIds, controller.tagIdsToTags);
-    var unifierTags =
-        tags.map((t) => unifierTagForTag(t, controller.tagIdsToTags));
+    var tags = convertTagIdsToTags(conversation.tagIds, controller.tagIdsToTags);
+    var unifierTags = tags.map((t) => unifierTagForTag(t, controller.tagIdsToTags));
     var unifierTagIds = tagsToTagIds(unifierTags).toSet();
-    if (!unifierTagIds.containsAll(filterTagIds[TagFilterType.include]))
-      return false;
-    if (unifierTagIds
-        .intersection(filterTagIds[TagFilterType.exclude])
-        .isNotEmpty) return false;
-    if (!unifierTagIds.containsAll(filterTagIds[TagFilterType.lastInboundTurn]))
-      return false;
+    if (!unifierTagIds.containsAll(filterTagIdsAll[TagFilterType.include])) return false;
+    if (unifierTagIds.intersection(filterTagIdsAll[TagFilterType.exclude]).isNotEmpty) return false;
+    if (!unifierTagIds.containsAll(filterTagIdsAll[TagFilterType.lastInboundTurn])) return false;
 
-    if (!conversation.docId.startsWith(conversationIdFilter) &&
-        !conversation.shortDeidentifiedPhoneNumber
-            .startsWith(conversationIdFilter)) return false;
+    if (!conversation.docId.startsWith(conversationIdFilter) && !conversation.shortDeidentifiedPhoneNumber.startsWith(conversationIdFilter)) return false;
 
     return true;
   }
 
   // This must be called after every change to the filters
   void _applyMandatoryFilters() {
-    if (userConfig != null)
-      _filterTags[TagFilterType.exclude].addAll(convertTagIdsToTags(
-          userConfig.mandatoryExcludeTagIds, controller.tagIdsToTags));
+    if (userConfig.mandatoryExcludeTagIds != null)
+      _filterTags[TagFilterType.exclude].addAll(convertTagIdsToTags(userConfig.mandatoryExcludeTagIds, controller.tagIdsToTags));
 
     if (userConfig.mandatoryIncludeTagIds != null)
-      _filterTags[TagFilterType.include].addAll(convertTagIdsToTags(
-          userConfig.mandatoryIncludeTagIds, controller.tagIdsToTags));
+      _filterTags[TagFilterType.include].addAll(convertTagIdsToTags(userConfig.mandatoryIncludeTagIds, controller.tagIdsToTags));
   }
 
-  Set<model.Tag> _getTagsFromUrl(
-      TagFilterType type, Map<String, model.Tag> tags) {
+  void _removeMandatoryFilters() {
+    if (userConfig != null && userConfig.mandatoryExcludeTagIds != null) {
+      var urlTags = _getTagsFromUrl(TagFilterType.exclude, controller.tagIdsToTags);
+      _filterTags[TagFilterType.exclude].removeWhere((tag) => userConfig.mandatoryExcludeTagIds.contains(tag.tagId) && !urlTags.any((urlTag) => urlTag.tagId == tag.tagId));
+    }
+
+    if (userConfig != null && userConfig.mandatoryIncludeTagIds != null) {
+      var urlTags = _getTagsFromUrl(TagFilterType.include, controller.tagIdsToTags);
+      _filterTags[TagFilterType.include].removeWhere((tag) => userConfig.mandatoryIncludeTagIds.contains(tag.tagId) && !urlTags.any((urlTag) => urlTag.tagId == tag.tagId));
+    }
+  }
+
+  Set<model.Tag> _getTagsFromUrl(TagFilterType type, Map<String, model.Tag> tags) {
     Set<String> filterTagIds = _view.urlView.getPageUrlFilterTags(type);
     var filterTags = convertTagIdsToTags(filterTagIds, tags);
     var unifierFilterTags = filterTags.map((t) => unifierTagForTag(t, tags));

--- a/webapp/lib/app/nook/controller_view_helper.dart
+++ b/webapp/lib/app/nook/controller_view_helper.dart
@@ -95,13 +95,13 @@ void _updateConversationPanelView(model.Conversation conversation) {
 List<TagView> _generateMessageTagViews(model.Message message) {
   List<TagView> tags = [];
   for (var tag in convertTagIdsToTags(message.tagIds, controller.tagIdsToTags)) {
-    bool shouldHighlightTag = controller.conversationFilter.filterTagIds[TagFilterType.include].contains(tag.tagId);
-    shouldHighlightTag = shouldHighlightTag || controller.conversationFilter.filterTagIds[TagFilterType.lastInboundTurn].contains(tag.tagId);
+    bool shouldHighlightTag = controller.conversationFilter.filterTagIdsManuallySet[TagFilterType.include].contains(tag.tagId);
+    shouldHighlightTag = shouldHighlightTag || controller.conversationFilter.filterTagIdsManuallySet[TagFilterType.lastInboundTurn].contains(tag.tagId);
     tags.add(new MessageTagView(tag.text, tag.tagId, tagTypeToKKStyle(tag.type), shouldHighlightTag));
   }
   for (var tag in convertTagIdsToTags(message.suggestedTagIds, controller.tagIdsToTags)) {
-    bool shouldHighlightTag = controller.conversationFilter.filterTagIds[TagFilterType.include].contains(tag.tagId);
-    shouldHighlightTag = shouldHighlightTag || controller.conversationFilter.filterTagIds[TagFilterType.lastInboundTurn].contains(tag.tagId);
+    bool shouldHighlightTag = controller.conversationFilter.filterTagIdsManuallySet[TagFilterType.include].contains(tag.tagId);
+    shouldHighlightTag = shouldHighlightTag || controller.conversationFilter.filterTagIdsManuallySet[TagFilterType.lastInboundTurn].contains(tag.tagId);
     tags.add(new SuggestedMessageTagView(tag.text, tag.tagId, tagTypeToKKStyle(tag.type), shouldHighlightTag));
   }
   return tags;


### PR DESCRIPTION
This fixes some issues with the mandatory filtering:
* live reaction to changes to the filters in Firebase and updates them as needed - fixes https://github.com/larksystems/Katikati-Core/issues/615
* correctly supports mandatory filtering in firebase becoming more permissive

It also adjusts mandatory filtering so that
* only tags added manually to the filter are highlighted on the conversation (likely fit to the use case of using filters to search for messages)
* only the manually added filters are added to the URL when the URL is updated (this is to ensure that when sharing URLs, only the manually added tags are carried over)