### PR TITLE
Ask for confirmation before the user leaves the configure pages

### DIFF
--- a/webapp/lib/app/configurator/standard_messages/controller.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller.dart
@@ -153,11 +153,7 @@ class MessagesConfiguratorController extends ConfiguratorController {
 
     log.verbose('After -- ${standardMessagesManager.categories}');
 
-    if (standardMessagesManager.hasUnsavedMessages) {
-      _view.enableSaveButton();
-    } else {
-      _view.disableSaveButton();
-    }
+    _view.unsavedChanges = standardMessagesManager.hasUnsavedMessages;
   }
 
   @override
@@ -182,7 +178,7 @@ class MessagesConfiguratorController extends ConfiguratorController {
       standardMessagesManager.editedMessages.clear();
       if (otherPartSaved) {
         _view.showSaveStatus('Saved!');
-        _view.disableSaveButton();
+        _view.unsavedChanges = false;
         return;
       }
       otherPartSaved = true;
@@ -194,7 +190,7 @@ class MessagesConfiguratorController extends ConfiguratorController {
       standardMessagesManager.deletedMessages.clear();
       if (otherPartSaved) {
         _view.showSaveStatus('Saved!');
-        _view.disableSaveButton();
+        _view.unsavedChanges = false;
         return;
       }
       otherPartSaved = true;

--- a/webapp/lib/app/configurator/tags/controller.dart
+++ b/webapp/lib/app/configurator/tags/controller.dart
@@ -135,11 +135,7 @@ class TagsConfiguratorController extends ConfiguratorController {
       default:
     }
 
-    if (tagManager.hasUnsavedTags) {
-      _view.enableSaveButton();
-    } else {
-      _view.disableSaveButton();
-    }
+    _view.unsavedChanges = tagManager.hasUnsavedTags;
   }
 
   @override
@@ -164,7 +160,7 @@ class TagsConfiguratorController extends ConfiguratorController {
       tagManager.editedTags.clear();
       if (otherPartSaved) {
         _view.showSaveStatus('Saved!');
-        _view.disableSaveButton();
+        _view.unsavedChanges = false;
         return;
       }
       otherPartSaved = true;
@@ -176,7 +172,7 @@ class TagsConfiguratorController extends ConfiguratorController {
       tagManager.deletedTags.clear();
       if (otherPartSaved) {
         _view.showSaveStatus('Saved!');
-        _view.disableSaveButton();
+        _view.unsavedChanges = false;
         return;
       }
       otherPartSaved = true;

--- a/webapp/lib/app/configurator/view.dart
+++ b/webapp/lib/app/configurator/view.dart
@@ -24,6 +24,24 @@ class ConfigurationPageView extends PageView {
   ButtonElement saveConfigurationButton;
   SpanElement saveStatusElement;
 
+  bool _unsavedChanges = false;
+
+  bool get unsavedChanges => _unsavedChanges;
+  set unsavedChanges(bool status) {
+    if (status == _unsavedChanges) {
+      return;
+    }
+
+    _unsavedChanges = status;
+    if (status) {
+      _enableSaveButton();
+      _addConfirmationOnLeave();
+    } else {
+      _disableSaveButton();
+      _removeConfirmationOnLeave();
+    }
+  }
+
   ConfigurationPageView(ConfiguratorController controller) : super(controller) {
     renderElement = new DivElement()..classes.add('configuration-view');
 
@@ -71,17 +89,31 @@ class ConfigurationPageView extends PageView {
     new Timer(new Duration(milliseconds: _ANIMATION_LENGTH_MS), () => saveStatusElement.text = '');
   }
 
-  void enableSaveButton() {
+  void _enableSaveButton() {
     saveConfigurationButton.removeAttribute('disabled');
     configurationActions.classes.toggle('sticky', true);
   }
 
-  void disableSaveButton() {
+  void _disableSaveButton() {
     saveConfigurationButton.setAttribute('disabled', 'true');
     new Timer(new Duration(milliseconds: 10 * _ANIMATION_LENGTH_MS), () {
       saveStatusElement.text = '';
       configurationActions.classes.toggle('sticky', false);
     });
+  }
+
+  // so that the same instance of function is passed to the add / remove listeners
+  Function(Event) _onLeaveListener = (Event event) {
+    var evt = event as BeforeUnloadEvent;
+    evt.returnValue = "";
+  };
+
+  void _addConfirmationOnLeave() {
+    window.addEventListener('beforeunload', _onLeaveListener, true);
+  }
+
+  void _removeConfirmationOnLeave() {
+    window.removeEventListener('beforeunload', _onLeaveListener, true);
   }
 }
 

--- a/webapp/lib/app/configurator/view.dart
+++ b/webapp/lib/app/configurator/view.dart
@@ -33,7 +33,7 @@ class ConfigurationPageView extends PageView {
     }
 
     _unsavedChanges = status;
-    if (status) {
+    if (_unsavedChanges) {
       _enableSaveButton();
       _addConfirmationOnLeave();
     } else {


### PR DESCRIPTION
+ Tested by editing the message, not saving, going to a different page (or refresh), alert pops up
+ Then clicked saved, navigate to different page, alert doesn't pop.

Closes https://github.com/larksystems/Katikati-Core/issues/631