### PR TITLE
Enable tag buttons on first load

### DIFF
--- a/webapp/lib/app/nook/controller.dart
+++ b/webapp/lib/app/nook/controller.dart
@@ -602,7 +602,7 @@ class NookController extends Controller {
     }
 
     if (oldConfig.tagConversationsEnabled != newConfig.tagConversationsEnabled) {
-        _view.tagPanelView.showButtons(newConfig.tagConversationsEnabled);
+      _view.tagPanelView.showButtons(newConfig.tagConversationsEnabled);
     }
 
     if (oldConfig.editTranslationsEnabled != newConfig.editTranslationsEnabled) {

--- a/webapp/lib/app/nook/controller.dart
+++ b/webapp/lib/app/nook/controller.dart
@@ -598,15 +598,11 @@ class NookController extends Controller {
     }
 
     if (oldConfig.tagMessagesEnabled != newConfig.tagMessagesEnabled) {
-      if (actionObjectState == UIActionObject.message) {
-        _view.tagPanelView.showButtons(newConfig.tagMessagesEnabled);
-      }
+      _view.tagPanelView.showButtons(newConfig.tagMessagesEnabled);
     }
 
     if (oldConfig.tagConversationsEnabled != newConfig.tagConversationsEnabled) {
-      if (actionObjectState == UIActionObject.conversation) {
         _view.tagPanelView.showButtons(newConfig.tagConversationsEnabled);
-      }
     }
 
     if (oldConfig.editTranslationsEnabled != newConfig.editTranslationsEnabled) {


### PR DESCRIPTION
+ `actionObjectState` is always `UIActionObject.loadingConversations` in this function, hence removed it from messages enabled as well. In any case, the enable / disable toggle should happen whenever the config changes irrespective of actionObjectState

Closes https://github.com/larksystems/Katikati-Core/issues/662