### PR TITLE
Replace conversation list update with set from scratch

### DIFF
--- a/webapp/lib/app/nook/controller_view_helper.dart
+++ b/webapp/lib/app/nook/controller_view_helper.dart
@@ -14,7 +14,6 @@ const SMS_MAX_LENGTH = 160;
 void _populateConversationListPanelView(Set<model.Conversation> conversations) {
   _view.conversationListPanelView.hideLoadSpinner();
   _view.conversationListPanelView.hideSelectConversationListMessage();
-  _view.conversationListPanelView.clearConversationList();
   _view.conversationListPanelView.updateConversationList(conversations);
 }
 

--- a/webapp/lib/app/nook/view.dart
+++ b/webapp/lib/app/nook/view.dart
@@ -940,54 +940,28 @@ class ConversationListPanelView {
     for (Conversation c in conversations) {
       conversationUuids.add(c.docId);
     }
-    List<ConversationSummary> conversationsToRemove = [];
-    for (var uuid in _phoneToConversations.keys) {
-      if (conversationUuids.contains(uuid)) continue;
-      conversationsToRemove.add(_phoneToConversations[uuid]);
-    }
-    _conversationList.removeItems(conversationsToRemove);
-    _phoneToConversations.removeWhere((key, value) => !conversationUuids.contains(key));
-
-    List<ConversationSummary> conversationsToAdd = [];
+    List<ConversationSummary> conversationSummaries = [];
     for (var conversation in conversations) {
       ConversationSummary summary = _phoneToConversations[conversation.docId];
-      if (summary != null) {
-        updateConversationSummary(summary, conversation);
-        continue;
+      if (summary == null) {
+        summary = new ConversationSummary(conversation.docId, "", false);
       }
-      summary = new ConversationSummary(
-          conversation.docId,
-          conversation.messages.isEmpty ? "No messages yet" : conversation.messages.last?.text,
-          isOurTurnInConversation(conversation));
-      conversationsToAdd.add(summary);
-    }
-    _conversationList.appendItems(conversationsToAdd);
-    for (var conversation in conversationsToAdd) {
-      _phoneToConversations[conversation.deidentifiedPhoneNumber] = conversation;
-    }
-    _conversationPanelTitle.text = _conversationPanelTitleText;
-  }
-
-  void addOrUpdateConversation(Conversation conversation) {
-    ConversationSummary summary = _phoneToConversations[conversation.docId];
-    if (summary != null) {
       updateConversationSummary(summary, conversation);
-      return;
+      _phoneToConversations[summary.deidentifiedPhoneNumber] = summary;
+      conversationSummaries.add(summary);
     }
-    summary = new ConversationSummary(
-        conversation.docId,
-        conversation.messages.last.text,
-        isOurTurnInConversation(conversation));
-    _conversationList.addItem(summary, null);
-    _phoneToConversations[summary.deidentifiedPhoneNumber] = summary;
+    ConversationSummary selectedConversation = _phoneToConversations[controller.activeConversation?.docId];
+    _conversationList.setItems(conversationSummaries, selectedConversation);
     _conversationPanelTitle.text = _conversationPanelTitleText;
   }
 
   void updateConversationSummary(ConversationSummary summary, Conversation conversation) {
+    summary._text = conversation.messages.isEmpty ? "No messages yet" : conversation.messages.last?.text;
     isOurTurnInConversation(conversation) ? summary._markUnread() : summary._markRead();
   }
 
   void selectConversation(String deidentifiedPhoneNumber) {
+    if (activeConversation?.deidentifiedPhoneNumber == deidentifiedPhoneNumber) return;
     activeConversation?._deselect();
     activeConversation = _phoneToConversations[deidentifiedPhoneNumber];
     activeConversation._select();
@@ -1265,6 +1239,7 @@ class ConversationSummary with LazyListViewItem, UserPresenceIndicator {
       _conversationItem.setWarnings(Set.from([ConversationWarning.notInFilterResults]));
     }
 
+    elementOrNull = _conversationItem.renderElement;
     return _conversationItem.renderElement;
   }
 


### PR DESCRIPTION
This fixes the previous logic which wasn't maintaining the sort order of the conversations correctly.

Also tries to reduce jitter in the conversation list when conversations update, but there is more that could be done on this.

And also fixes https://github.com/larksystems/Katikati-Core/issues/510 - this was caused by the lazy list class deciding whether to re-build an item based on `elementOrNull`, which wasn't being set (ie. was always `null`)