### PR TITLE
Fix current config reference for the conversation filter

### DIFF
--- a/webapp/lib/app/nook/controller.dart
+++ b/webapp/lib/app/nook/controller.dart
@@ -348,7 +348,7 @@ class NookController extends Controller {
     selectedTagGroup = '';
 
     // Get any filter tags from the url
-    conversationFilter = new ConversationFilter.fromUrl(currentUserConfig);
+    conversationFilter = new ConversationFilter.fromUrl(currentConfig);
     _populateSelectedFilterTags(conversationFilter.getFilters(TagFilterType.include), TagFilterType.include);
     _view.conversationIdFilter.filter = conversationFilter.conversationIdFilter;
 
@@ -400,7 +400,7 @@ class NookController extends Controller {
         _populateTagPanelView(tagsByGroup[selectedTagGroup]);
 
         // Re-read the conversation filter from the URL since we now have the names of the tags
-        conversationFilter = new ConversationFilter.fromUrl(currentUserConfig);
+        conversationFilter = new ConversationFilter.fromUrl(currentConfig);
         _populateSelectedFilterTags(conversationFilter.getFilters(TagFilterType.include), TagFilterType.include);
 
         if (currentConfig.conversationalTurnsEnabled) {


### PR DESCRIPTION
TBR  fixes https://github.com/larksystems/Katikati-Core/issues/671

@lukechurch an explanation for the issue, which I didn't catch when reviewing your PR: `currentUserConfig` refers to the configuration for the user, which is empty if the user is to use the defaults for mandatory tag filters, while `currentConfig` represents the configuration to be applied to the UI (ie. the merger of `default` and `currentUserConfig`)