### PR TITLE
Ignore shortcuts on interactive html elements

### DIFF
--- a/webapp/lib/app/nook/dom_utils.dart
+++ b/webapp/lib/app/nook/dom_utils.dart
@@ -1,5 +1,7 @@
 import 'dart:html';
 
+const IGNORE_ON_ELEMENTS = ["INPUT", "TEXTAREA", "SELECT", "BUTTON", "A"];
+
 List<Element> getAncestors(Element element) {
   List<Element> ancestors = [element];
   while (element != null) {
@@ -7,4 +9,20 @@ List<Element> getAncestors(Element element) {
     element = element.parent;
   }
   return ancestors;
+}
+
+// https://stackoverflow.com/questions/28062737/javascript-keydown-shortcut-function-but-ignore-if-in-text-box
+bool ignoreShortcut(KeyboardEvent event) {
+  var target = (event.target as HtmlElement);
+  var targetType = target.tagName;
+
+  if (IGNORE_ON_ELEMENTS.contains(targetType)) {
+    return true;
+  }
+
+  if (target.contentEditable == "true") {
+    return true;
+  }
+
+  return false;
 }

--- a/webapp/lib/app/nook/view.dart
+++ b/webapp/lib/app/nook/view.dart
@@ -67,8 +67,10 @@ class NookPageView extends PageView {
     };
     conversationIdFilter = conversationListPanelView.conversationIdFilter;
 
-    document.onKeyDown.listen(
-      (event) => appController.command(UIAction.keyPressed, new KeyPressData(event.key, event.altKey || event.ctrlKey || event.metaKey || event.shiftKey)));
+    document.onKeyDown.listen((event) {
+      if (ignoreShortcut(event)) return;
+      appController.command(UIAction.keyPressed, new KeyPressData(event.key, event.altKey || event.ctrlKey || event.metaKey || event.shiftKey));
+    });
   }
 
   void initSignedInView(String displayName, String photoUrl) {
@@ -186,15 +188,10 @@ void makeEditable(Element element, {void onChange(e), void onEnter(e)}) {
   element
     ..contentEditable = 'true'
     ..onBlur.listen((e) {
-      e.stopPropagation();
       if (onChange != null) onChange(e);
     })
-    ..onKeyPress.listen((e) => e.stopPropagation())
-    ..onKeyUp.listen((e) => e.stopPropagation())
     ..onKeyDown.listen((e) {
-      e.stopPropagation();
       if (onEnter != null && e.keyCode == KeyCode.ENTER) {
-        e.stopImmediatePropagation();
         onEnter(e);
       }
     });
@@ -1225,10 +1222,10 @@ class ConversationIdFilter {
 
     _idInput = new TextInputElement()
       ..classes.add('conversation-filter__input')
-      ..placeholder = 'Enter conversation ID';
-    makeEditable(_idInput, onChange: (_) {
-      _view.appController.command(UIAction.updateConversationIdFilter, new ConversationIdFilterData(_idInput.value));
-    });
+      ..placeholder = 'Enter conversation ID'
+      ..onChange.listen((_) {
+        _view.appController.command(UIAction.updateConversationIdFilter, new ConversationIdFilterData(_idInput.value));
+      });
     conversationFilter.append(_idInput);
   }
 


### PR DESCRIPTION
+ Instead of stop propagation on every interactive element, we have a generic function that determines if the shortcut is applicable or not. e.g. this handles "Enter" on a button, but when we author a button element we do not necessarily think of adding stopPropogation onKeyDown

+ Removed stopPropogations on makeEditable as they are not needed anymore

Closes https://github.com/larksystems/Katikati-Core/issues/670