### PR TITLE
Reflect conversation summary status in the conversation from changes in the conversation from firebase

### DIFF
--- a/webapp/lib/app/nook/controller.dart
+++ b/webapp/lib/app/nook/controller.dart
@@ -3,6 +3,7 @@ library controller;
 import 'dart:async';
 import 'dart:collection';
 import 'package:firebase/firebase.dart' show FirebaseError;
+import 'package:katikati_ui_lib/components/conversation/conversation_item.dart';
 
 import 'package:katikati_ui_lib/components/url_view/url_view.dart';
 import 'package:katikati_ui_lib/components/snackbar/snackbar.dart';
@@ -1451,6 +1452,7 @@ class NookController extends Controller {
       ..translation = reply.translation
       ..tagIds = []
       ..status = model.MessageStatus.pending;
+    _view.conversationListPanelView.updateConversationStatus(conversation.docId, ConversationItemStatus.pending);
     log.verbose('Adding reply "${reply.text}" to conversation ${conversation.docId}');
     conversation.messages.add(newMessage);
     _view.conversationPanelView.addMessage(_generateMessageView(newMessage, conversation));
@@ -1459,6 +1461,7 @@ class NookController extends Controller {
       log.error('Reply "${reply.text}" failed to be sent to conversation ${conversation.docId}');
       log.error('Error: ${error}');
       command(UIAction.showSnackbar, new SnackbarData('Send Reply Failed', SnackbarNotificationType.error));
+      _view.conversationListPanelView.updateConversationStatus(conversation.docId, ConversationItemStatus.failed);
       newMessage.status = model.MessageStatus.failed;
       if (conversation.docId == activeConversation.docId) {
         int newMessageIndex = activeConversation.messages.indexOf(newMessage);
@@ -1481,6 +1484,7 @@ class NookController extends Controller {
         ..translation = reply.translation
         ..tagIds = []
         ..status = model.MessageStatus.pending;
+      _view.conversationListPanelView.updateConversationStatus(conversation.docId, ConversationItemStatus.pending);
       newMessages[conversation.docId] = newMessage;
       conversation.messages.add(newMessage);
       if (conversation.docId == activeConversation.docId) {
@@ -1493,6 +1497,9 @@ class NookController extends Controller {
       log.error('Reply "${reply.text}" failed to be sent to conversations ${conversationIds}');
       log.error('Error: ${error}');
       command(UIAction.showSnackbar, new SnackbarData('Send Multi Reply Failed', SnackbarNotificationType.error));
+      conversationIds.forEach((conversationId) {
+        _view.conversationListPanelView.updateConversationStatus(conversationId, ConversationItemStatus.pending);
+      });
       for (var newMessage in newMessages.values) {
         newMessage.status = model.MessageStatus.failed;
       }
@@ -1519,6 +1526,7 @@ class NookController extends Controller {
         ..translation = reply.translation
         ..tagIds = []
         ..status = model.MessageStatus.pending;
+        _view.conversationListPanelView.updateConversationStatus(conversation.docId, ConversationItemStatus.pending);
       newMessages.add(newMessage);
       conversation.messages.add(newMessage);
       _view.conversationPanelView.addMessage(_generateMessageView(newMessage, conversation));
@@ -1529,6 +1537,7 @@ class NookController extends Controller {
       log.error('${textReplies.length} replies "${repliesStr}" failed to be sent to conversation ${conversation.docId}');
       log.error('Error: ${error}');
       command(UIAction.showSnackbar, new SnackbarData('Send Reply Failed', SnackbarNotificationType.error));
+      _view.conversationListPanelView.updateConversationStatus(conversation.docId, ConversationItemStatus.failed);
       for (var message in newMessages) {
         message.status = model.MessageStatus.failed;
         if (conversation.docId == activeConversation.docId) {
@@ -1557,6 +1566,7 @@ class NookController extends Controller {
           ..translation = reply.translation
           ..tagIds = []
           ..status = model.MessageStatus.pending;
+        _view.conversationListPanelView.updateConversationStatus(conversation.docId, ConversationItemStatus.pending);
         newMessages.add(newMessage);
         conversation.messages.add(newMessage);
         if (conversation.docId == activeConversation.docId) {
@@ -1570,6 +1580,9 @@ class NookController extends Controller {
       log.error('${textReplies.length} replies "${repliesStr}" failed to be sent to conversations ${conversationIds}');
       log.error('Error: ${error}');
       command(UIAction.showSnackbar, new SnackbarData('Send Multi Reply Failed', SnackbarNotificationType.error));
+      conversationIds.forEach((conversationId) {
+        _view.conversationListPanelView.updateConversationStatus(conversationId, ConversationItemStatus.pending);
+      });
       for (var conversationId in newMessagesByConversation.keys) {
         var newMessages = newMessagesByConversation[conversationId];
         for (var message in newMessages) {

--- a/webapp/lib/app/nook/view.dart
+++ b/webapp/lib/app/nook/view.dart
@@ -1020,11 +1020,11 @@ class ConversationListPanelView {
 
     bool hasPendingMessages = false;
     bool hasFailedMessages = false;
-    for(Message message in conversation.messages) {
-      if(message.status == MessageStatus.pending) {
+    for (Message message in conversation.messages) {
+      if (message.status == MessageStatus.pending) {
         hasPendingMessages = true;
         if (hasFailedMessages) break;
-      } else if(message.status == MessageStatus.failed) {
+      } else if (message.status == MessageStatus.failed) {
         hasFailedMessages = true;
         break;
       }

--- a/webapp/lib/app/nook/view.dart
+++ b/webapp/lib/app/nook/view.dart
@@ -1009,6 +1009,13 @@ class ConversationListPanelView {
     _conversationPanelTitle.text = _conversationPanelTitleText;
   }
 
+  void updateConversationStatus(String conversationDocId, ConversationItemStatus status) {
+    ConversationSummary summary = _phoneToConversations[conversationDocId];
+    if (summary != null) {
+      summary._updateStatus(status);
+    }
+  }
+
   void updateConversationSummary(ConversationSummary summary, Conversation conversation, UIConversationSort sortOrder) {
     var messageText = conversation.messages.isEmpty ? "No messages yet" : conversation.messages.last?.text;
     var messageDateTime = conversation.messages.isEmpty ? null : conversation.messages.last?.datetime;

--- a/webapp/lib/app/nook/view.dart
+++ b/webapp/lib/app/nook/view.dart
@@ -998,7 +998,7 @@ class ConversationListPanelView {
     for (var conversation in conversations) {
       ConversationSummary summary = _phoneToConversations[conversation.docId];
       if (summary == null) {
-        summary = new ConversationSummary(conversation.docId, "", false, dateTime: conversation.messages.isEmpty ? null : conversation.messages.last.datetime);
+        summary = new ConversationSummary(conversation.docId, "", false, ConversationItemStatus.normal, dateTime: conversation.messages.isEmpty ? null : conversation.messages.last.datetime);
       }
       updateConversationSummary(summary, conversation, sortOrder);
       _phoneToConversations[summary.deidentifiedPhoneNumber] = summary;
@@ -1017,9 +1017,23 @@ class ConversationListPanelView {
       messageText = conversation.mostRecentMessageInbound == null ? "No inbound message" : conversation.mostRecentMessageInbound.text;
       messageDateTime = conversation.mostRecentMessageInbound == null ? null : conversation.mostRecentMessageInbound.datetime;
     }
+
+    bool hasPendingMessages = false;
+    bool hasFailedMessages = false;
+    for(Message message in conversation.messages) {
+      if(message.status == MessageStatus.pending) {
+        hasPendingMessages = true;
+        if (hasFailedMessages) break;
+      } else if(message.status == MessageStatus.failed) {
+        hasFailedMessages = true;
+        break;
+      }
+    }
+    
     summary
       .._updateText(messageText)
-      .._updateDateTime(messageDateTime);
+      .._updateDateTime(messageDateTime)
+      .._updateStatus(hasFailedMessages ? ConversationItemStatus.failed : hasPendingMessages ? ConversationItemStatus.pending : ConversationItemStatus.normal);
     conversationNeedsReply(conversation) ? summary._markUnread() : summary._markRead();
   }
 
@@ -1278,6 +1292,7 @@ class ConversationSummary with LazyListViewItem, UserPresenceIndicator {
   bool _selected = false;
   bool _checkboxHidden = true;
   bool _warning = false;
+  ConversationItemStatus _status;
 
   // HACK(mariana): This should get extracted from the model as it gets computed there for the single conversation view
   String get _shortDeidentifiedPhoneNumber => deidentifiedPhoneNumber.split('uuid-')[1].split('-')[0];
@@ -1285,13 +1300,13 @@ class ConversationSummary with LazyListViewItem, UserPresenceIndicator {
 
   Map<String, bool> _presentUsers = {};
 
-  ConversationSummary(this.deidentifiedPhoneNumber, this._text, this._unread, {dateTime: DateTime}) {
+  ConversationSummary(this.deidentifiedPhoneNumber, this._text, this._unread, this._status, {dateTime: DateTime}) {
     _dateTime = dateTime;
     otherUserPresenceIndicator = new DivElement()..classes.add('conversation-list__user-indicators')..classes.add('user-indicators');
   }
 
   Element buildElement() {
-    _conversationItem = ConversationItemView(_shortDeidentifiedPhoneNumber, _text, ConversationItemStatus.normal, readStatus, checkEnabled: !_checkboxHidden, defaultSelected: _selected, dateTime: _dateTime)
+    _conversationItem = ConversationItemView(_shortDeidentifiedPhoneNumber, _text, _status, readStatus, checkEnabled: !_checkboxHidden, defaultSelected: _selected, dateTime: _dateTime)
       ..onCheck.listen((_) {
         _view.appController.command(UIAction.selectConversation, new ConversationData(deidentifiedPhoneNumber));
       })
@@ -1361,6 +1376,11 @@ class ConversationSummary with LazyListViewItem, UserPresenceIndicator {
 
   void _toggleDateSeparator(bool show) {
     _conversationItem?.toggleDateSeparator(show);
+  }
+
+  void _updateStatus(ConversationItemStatus status) {
+    _status = status;
+    _conversationItem?.updateStatus(status);
   }
 
   void _showCheckbox(bool show) {


### PR DESCRIPTION
Noticed a bug where the conversation summary doesn't show any of the pending or failed statuses