### PR TITLE
Fix user presence indicator not being on the conversation item

### DIFF
--- a/webapp/lib/app/nook/view.dart
+++ b/webapp/lib/app/nook/view.dart
@@ -1072,7 +1072,7 @@ class ConversationListPanelView {
         break;
       }
     }
-    
+
     summary
       .._updateText(messageText)
       .._updateDateTime(messageDateTime)
@@ -1452,7 +1452,7 @@ class ConversationSummary with LazyListViewItem, UserPresenceIndicator {
   @override
   void showOtherUserPresence(String userId, bool recent) {
     if (_presentUsers.isEmpty) {
-      elementOrNull?.append(otherUserPresenceIndicator);
+      _conversationItem.conversationItem.append(otherUserPresenceIndicator);
     }
     super.showOtherUserPresence(userId, recent);
   }
@@ -2057,7 +2057,7 @@ class ChangeSortOrderActionView {
     renderElement.append(SpanElement()..className = "fas fa-sort-amount-down");
     renderElement.append(_selectOrder);
   }
-  
+
   void _changeSortOrder(Event e) {
     switch ((e.currentTarget as SelectElement).value) {
       case 'alphabetically':
@@ -2079,7 +2079,7 @@ class ChangeSortOrderActionView {
         _selectOrder.selectedIndex = 1;
         break;
       case UIConversationSort.alphabeticalById:
-        _selectOrder.selectedIndex = 2;   
+        _selectOrder.selectedIndex = 2;
         break;
       case UIConversationSort.mostRecentMessageFirst:
       default:

--- a/webapp/pubspec.lock
+++ b/webapp/pubspec.lock
@@ -264,8 +264,8 @@ packages:
     dependency: "direct main"
     description:
       path: ui
-      ref: "01fd80dc07a1b3627d461ad3ed1ae5de1dfd7a48"
-      resolved-ref: "01fd80dc07a1b3627d461ad3ed1ae5de1dfd7a48"
+      ref: ac2a6d4f6f03165aa7328a8463a4dcb3528cbeab
+      resolved-ref: ac2a6d4f6f03165aa7328a8463a4dcb3528cbeab
       url: "git@github.com:larksystems/katikati_common_lib.git"
     source: git
     version: "0.0.1"

--- a/webapp/pubspec.yaml
+++ b/webapp/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     git:
       url: git@github.com:larksystems/katikati_common_lib.git
       path: ui
-      ref: 01fd80dc07a1b3627d461ad3ed1ae5de1dfd7a48
+      ref: ac2a6d4f6f03165aa7328a8463a4dcb3528cbeab
 
 dev_dependencies:
   build_runner: ^1.7.0

--- a/webapp/web/converse/styles.css
+++ b/webapp/web/converse/styles.css
@@ -223,7 +223,7 @@ main {
 
 .conversation-list__user-indicators {
     position: absolute;
-    top: 8px;
+    bottom: 8px;
     right: 8px;
 }
 


### PR DESCRIPTION
Fixes https://github.com/larksystems/Katikati-Core/issues/692

The problem was that the conversation item is now wrapped in a classless div, and the other user presence indicator requires its parent to be relative so it can position itself floating on top, relative to top/bottom.

Also moves it to the bottom so it doesn't appear on top of the datetime