### PR TITLE
fix enter misbehaving on inline tag creation

### DIFF
--- a/webapp/lib/app/nook/view.dart
+++ b/webapp/lib/app/nook/view.dart
@@ -192,7 +192,7 @@ void makeEditable(Element element, {void onChange(e), void onEnter(e)}) {
     ..onBlur.listen((e) {
       if (onChange != null) onChange(e);
     })
-    ..onKeyDown.listen((e) {
+    ..onKeyUp.listen((e) {
       if (onEnter != null && e.keyCode == KeyCode.ENTER) {
         onEnter(e);
       }

--- a/webapp/pubspec.lock
+++ b/webapp/pubspec.lock
@@ -264,8 +264,8 @@ packages:
     dependency: "direct main"
     description:
       path: ui
-      ref: ac2a6d4f6f03165aa7328a8463a4dcb3528cbeab
-      resolved-ref: ac2a6d4f6f03165aa7328a8463a4dcb3528cbeab
+      ref: "9bb084f40fd36689a520eacde7e3b9f87f088eec"
+      resolved-ref: "9bb084f40fd36689a520eacde7e3b9f87f088eec"
       url: "git@github.com:larksystems/katikati_common_lib.git"
     source: git
     version: "0.0.1"

--- a/webapp/pubspec.yaml
+++ b/webapp/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     git:
       url: git@github.com:larksystems/katikati_common_lib.git
       path: ui
-      ref: ac2a6d4f6f03165aa7328a8463a4dcb3528cbeab
+      ref: 9bb084f40fd36689a520eacde7e3b9f87f088eec
 
 dev_dependencies:
   build_runner: ^1.7.0


### PR DESCRIPTION
bringing in https://github.com/larksystems/katikati_common_lib/pull/103 to fix enter on inline tag creation moving to the next conversation (and changing the `makeEditable` to react on `onKeyUp`, which is more consistent with desired behaviour

TBR