### PR TITLE
Add a "start of conversation" before the first message

### DIFF
--- a/webapp/lib/app/nook/view.dart
+++ b/webapp/lib/app/nook/view.dart
@@ -420,6 +420,11 @@ class ConversationPanelView with AutomaticSuggestionIndicator {
     for (int i = 0; i < messagesNo; i++) {
       _messages.firstChild.remove();
     }
+
+    var startOfConversation = DivElement()
+      ..classes.add("messages-date-separator")
+      ..innerText = "You have reached the start of conversation";
+    _messages.append(startOfConversation);
   }
 
   void updateDateSeparators() {

--- a/webapp/web/converse/styles.css
+++ b/webapp/web/converse/styles.css
@@ -345,6 +345,7 @@ main {
     padding: 2px 4px;
     font-size: 0.8em;
     border-radius: 2px;
+    text-align: center;
 }
 
 .notes-panel {


### PR DESCRIPTION
When there are no messages, the conversation panel is empty. The user might be confused if the messages loaded or not.