### PR TITLE
Always show the last message of the conversation

### DIFF
--- a/webapp/lib/app/nook/view.dart
+++ b/webapp/lib/app/nook/view.dart
@@ -1057,7 +1057,6 @@ class ConversationListPanelView {
     var messageDateTime = conversation.messages.isEmpty ? null : conversation.messages.last?.datetime;
 
     if (sortOrder == UIConversationSort.mostRecentInMessageFirst) {
-      messageText = conversation.mostRecentMessageInbound == null ? "No inbound message" : conversation.mostRecentMessageInbound.text;
       messageDateTime = conversation.mostRecentMessageInbound == null ? null : conversation.mostRecentMessageInbound.datetime;
     }
 


### PR DESCRIPTION
TBR

@elayabharath Unfortunately in practice, showing the last incoming message instead of the last message in the conversation, even when sorted by last incoming message is pretty confusing. We'll need to work out what to do about the datetime - currently we show the datetime of the last incoming message, but we might need to show both - I'm not sure yet.