### PR TITLE
Improvements and extension to project config handling

### DIFF
--- a/webapp/lib/app/configurator/standard_messages/controller.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller.dart
@@ -72,6 +72,10 @@ class MessagesConfiguratorController extends ConfiguratorController {
 
   MessagesConfiguratorController() : super() {
     _controller = this;
+  }
+
+  @override
+  void init() {
     view = new MessagesConfigurationPageView(this);
     platform = new Platform(this);
   }

--- a/webapp/lib/app/configurator/standard_messages/view.dart
+++ b/webapp/lib/app/configurator/standard_messages/view.dart
@@ -243,21 +243,21 @@ class MessageView {
 
     var textLengthIndicator = new SpanElement()
       ..classes.add('message__length-indicator')
-      ..classes.toggle('message__length-indicator--alert', message.length > 160)
-      ..text = '${message.length}/160';
+      ..classes.toggle('message__length-indicator--alert', message.length > _view.appController.MESSAGE_MAX_LENGTH)
+      ..text = '${message.length}/${_view.appController.MESSAGE_MAX_LENGTH}';
 
     _messageText = new TextAreaElement()
       ..classes.add('message__text')
-      ..classes.toggle('message__text--alert', message.length > 160)
+      ..classes.toggle('message__text--alert', message.length > _view.appController.MESSAGE_MAX_LENGTH)
       ..text = message != null ? message : ''
       ..placeholder = placeholder
       ..contentEditable = 'true'
       ..onBlur.listen((event) => onMessageUpdateCallback((event.target as TextAreaElement).value))
       ..onInput.listen((event) {
         int count = _messageText.value.split('').length;
-        textLengthIndicator.text = '${count}/160';
-        _messageText.classes.toggle('message__text--alert', count > 160);
-        textLengthIndicator.classes.toggle('message__length-indicator--alert', count > 160);
+        textLengthIndicator.text = '${count}/${_view.appController.MESSAGE_MAX_LENGTH}';
+        _messageText.classes.toggle('message__text--alert', count > _view.appController.MESSAGE_MAX_LENGTH);
+        textLengthIndicator.classes.toggle('message__length-indicator--alert', count > _view.appController.MESSAGE_MAX_LENGTH);
         _handleTextareaHeightChange();
       });
 

--- a/webapp/lib/app/configurator/tags/controller.dart
+++ b/webapp/lib/app/configurator/tags/controller.dart
@@ -68,6 +68,10 @@ class TagsConfiguratorController extends ConfiguratorController {
 
   TagsConfiguratorController() : super() {
     _controller = this;
+  }
+
+  @override
+  void init() {
     view = new TagsConfigurationPageView(this);
     platform = new Platform(this);
   }

--- a/webapp/lib/app/homepage/controller.dart
+++ b/webapp/lib/app/homepage/controller.dart
@@ -11,7 +11,10 @@ Logger log = new Logger('controller.dart');
 
 class HomePageController extends Controller {
 
-  HomePageController() : super() {
+  HomePageController() : super() {}
+
+  @override
+  void init() {
     view = new HomePageView(this,
       [pages[Page.converse]],
       [pages[Page.configureMessages], pages[Page.configureTags]],

--- a/webapp/lib/app/nook/controller.dart
+++ b/webapp/lib/app/nook/controller.dart
@@ -27,8 +27,8 @@ part 'controller_view_helper.dart';
 
 Logger log = new Logger('controller.dart');
 
-const ENABLE_TURNLINE_PANEL = false;
-const DEFAULT_PANEL_TAB = 'standard_messages';
+bool get ENABLE_TURNLINE_PANEL => controller.projectConfiguration['nookTurnlineEnabled'] ?? false;
+String get DEFAULT_PANEL_TAB => controller.projectConfiguration['nookDefaultPanel'] ?? 'standard_messages';
 
 enum UIActionObject {
   conversation,
@@ -349,9 +349,13 @@ class NookController extends Controller {
 
   NookController() : super() {
     controller = this;
+  }
 
+  @override
+  void init() {
     defaultUserConfig = baseUserConfiguration;
     currentUserConfig = currentConfig = emptyUserConfiguration;
+
     view = new NookPageView(this);
     platform = new Platform(this);
     userPositionReporter = UserPositionReporter();

--- a/webapp/lib/app/nook/controller_view_helper.dart
+++ b/webapp/lib/app/nook/controller_view_helper.dart
@@ -7,8 +7,6 @@ const DELETE_SUGGESTED_REPLY_BUTTON_TEXT = 'DELETE suggested messages';
 
 const TAG_CONVERSATION_BUTTON_TEXT = 'TAG';
 
-const SMS_MAX_LENGTH = 160;
-
 // Functions to populate the views with model objects.
 
 void _populateConversationListPanelView(Set<model.Conversation> conversations, UIConversationSort sortOrder) {

--- a/webapp/lib/app/nook/view.dart
+++ b/webapp/lib/app/nook/view.dart
@@ -27,7 +27,6 @@ import 'controller.dart';
 import 'dom_utils.dart';
 import 'lazy_list_view_model.dart';
 
-const SMS_MAX_LENGTH = 160;
 const ENABLE_NEW_CONVERSTION = false;
 
 Logger log = new Logger('view.dart');
@@ -282,7 +281,7 @@ class ConversationPanelView with AutomaticSuggestionIndicator {
     });
     conversationPanel.append(_messages);
 
-    _freetextMessageSendView = FreetextMessageSendView("", maxLength: SMS_MAX_LENGTH)..onSend.listen((messageText) {
+    _freetextMessageSendView = FreetextMessageSendView("", maxLength: _view.appController.MESSAGE_MAX_LENGTH)..onSend.listen((messageText) {
       _view.appController.command(UIAction.sendManualMessage, new ManualReplyData(messageText));
     });
     conversationPanel.append(_freetextMessageSendView.renderElement);

--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -43,8 +43,6 @@ enum BaseAction {
 
   signInButtonClicked,
   signOutButtonClicked,
-
-  projectConfigurationLoaded,
 }
 
 class Data {}
@@ -91,18 +89,22 @@ class Controller {
     try {
       HttpRequest.getString('/assets/project_configuration.json').then((projectConfigurationJson) {
         projectConfiguration = json.decode(projectConfigurationJson);
-        command(BaseAction.projectConfigurationLoaded);
+        init();
       }, onError: (_) { /* Do nothing */ });
     } catch (e) { /* Do nothing */ }
   }
 
+  /// Method to be implemented by extending classes to initialise the view after the project configuration has been loaded
+  void init() {}
+
+  /// Method to be implemented by extending classes to respond to their own UI command datatype.
+  /// Any commands they don't recognise, they should pass them to super.command().
   void command(action, [Data data]) {
     switch (action) {
       case BaseAction.userSignedOut:
         signedInUser = null;
         tearDownOnLogout();
         view.initSignedOutView();
-        view.updateSignedOutViewWithProjectConfiguration();
         break;
 
       case BaseAction.userSignedIn:
@@ -111,7 +113,6 @@ class Controller {
           ..userName = userData.displayName
           ..userEmail = userData.email;
         view.initSignedInView(userData.displayName, userData.photoUrl);
-        view.updateSignedInViewWithProjectConfiguration();
         setUpOnLogin();
         break;
 
@@ -122,14 +123,6 @@ class Controller {
 
       case BaseAction.signOutButtonClicked:
         platform.signOut();
-        break;
-
-      case BaseAction.projectConfigurationLoaded:
-        if (signedInUser != null) {
-          view.updateSignedInViewWithProjectConfiguration();
-        } else {
-          view.updateSignedOutViewWithProjectConfiguration();
-        }
         break;
 
       case BaseAction.updateSystemMessages:
@@ -162,4 +155,10 @@ class Controller {
   }
 
   void routeToPage(Page page) => routeToPath(pages[page].urlPath);
+
+  /// Set of configuration options common across UIs
+  int get MESSAGE_MAX_LENGTH {
+    print('------ get message max length: ${projectConfiguration['textCharacterLimit']}');
+    return projectConfiguration['textCharacterLimit'] ?? 160;
+  }
 }

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -44,6 +44,7 @@ class PageView {
         () {}, // We don't show the navbar when the user is not logged in, so no need to show this
         () => appController.command(BaseAction.signOutButtonClicked));
     navHeaderView.authHeader = authHeaderView;
+    navHeaderView.projectTitle = appController.projectConfiguration['projectTitle'];
 
     snackbarView = new SnackbarView();
   }
@@ -69,16 +70,22 @@ class PageView {
 
     footerElement.append(snackbarView.snackbarElement);
   }
+}
 
-  void updateSignedInViewWithProjectConfiguration() {
-    navHeaderView?.projectTitle = appController.projectConfiguration['projectTitle'];
+/// The authentication page
+class LoginPage {
+  AuthMainView authView;
+
+  LoginPage() {
+    authView = new AuthMainView(
+        brand.KATIKATI,
+        _pageView.appController.projectConfiguration['loginTitle'] ?? '',
+        _pageView.appController.projectConfiguration['loginDescription'] ?? '',
+        _buildSignInDomainInfos(_pageView.appController.projectConfiguration['domainsInfo'] ?? {}),
+        (SignInDomainInfo domainInfo) => _pageView.appController.command(BaseAction.signInButtonClicked, new SignInData(domainInfo)));
   }
 
-  void updateSignedOutViewWithProjectConfiguration() {
-    loginPage?.authView?.title = appController.projectConfiguration['loginTitle'] ?? '';
-    loginPage?.authView?.description = appController.projectConfiguration['loginDescription'] ?? '';
-    loginPage?.authView?.domainsInfo = _buildSignInDomainInfos(appController.projectConfiguration['domainsInfo'] ?? {});
-  }
+  DivElement get renderElement => authView.authElement;
 
   List<SignInDomainInfo> _buildSignInDomainInfos(Map domains) {
     List<SignInDomainInfo> result = [];
@@ -88,18 +95,4 @@ class PageView {
     }
     return result;
   }
-}
-
-/// The authentication page
-class LoginPage {
-  AuthMainView authView;
-
-  LoginPage() {
-    authView = new AuthMainView(
-      brand.KATIKATI,
-      [KATIKATI_DOMAIN_INFO],
-      (SignInDomainInfo domainInfo) => _pageView.appController.command(BaseAction.signInButtonClicked, new SignInData(domainInfo)));
-  }
-
-  DivElement get renderElement => authView.authElement;
 }

--- a/webapp/pubspec.lock
+++ b/webapp/pubspec.lock
@@ -264,8 +264,8 @@ packages:
     dependency: "direct main"
     description:
       path: ui
-      ref: f3b9c58e3e17ce15a9f6eab60ae6489bc401e263
-      resolved-ref: f3b9c58e3e17ce15a9f6eab60ae6489bc401e263
+      ref: "7c146cbc4f048b67a4ed7c13e0f0269c8c5b3dd8"
+      resolved-ref: "7c146cbc4f048b67a4ed7c13e0f0269c8c5b3dd8"
       url: "git@github.com:larksystems/katikati_common_lib.git"
     source: git
     version: "0.0.1"

--- a/webapp/pubspec.yaml
+++ b/webapp/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     git:
       url: git@github.com:larksystems/katikati_common_lib.git
       path: ui
-      ref: f3b9c58e3e17ce15a9f6eab60ae6489bc401e263
+      ref: 7c146cbc4f048b67a4ed7c13e0f0269c8c5b3dd8
 
 dev_dependencies:
   build_runner: ^1.7.0


### PR DESCRIPTION
TBR @elayabharath 

This PR:
* adds max message length as something that can be specified per project
* also adds turnline enabling and default RHS panel to be specified per project
* changes project configuration load logic so that the project config is loaded first, then the UI/platform are initialised. This avoids having to support making changes to the UI elements after they've been displayed