### PR TITLE
Show only the status of the last message in the conversation list

### DIFF
--- a/webapp/lib/app/nook/view.dart
+++ b/webapp/lib/app/nook/view.dart
@@ -1079,14 +1079,10 @@ class ConversationListPanelView {
 
     bool hasPendingMessages = false;
     bool hasFailedMessages = false;
-    for (Message message in conversation.messages) {
-      if (message.status == MessageStatus.pending) {
-        hasPendingMessages = true;
-        if (hasFailedMessages) break;
-      } else if (message.status == MessageStatus.failed) {
-        hasFailedMessages = true;
-        break;
-      }
+    if (conversation.messages.isNotEmpty) {
+      Message lastMessage = conversation.messages.last;
+      hasPendingMessages = lastMessage.status == MessageStatus.pending;
+      hasFailedMessages = lastMessage.status == MessageStatus.failed;
     }
 
     summary


### PR DESCRIPTION
We don't need to draw attention to old failed messages, so just use the last message instead

TBR