### PR TITLE
Refactor messages configuration page to use (category/groupId) instead of (category/group)Name

### DIFF
--- a/webapp/lib/app/configurator/standard_messages/controller.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller.dart
@@ -115,18 +115,8 @@ class MessagesConfiguratorController extends ConfiguratorController {
       case MessagesConfigAction.updateStandardMessage:
         StandardMessageData messageData = data;
         var standardMessage = standardMessagesManager.modifyMessage(messageData.messageId, messageData.text, messageData.translation);
-        String categoryName;
-        String groupName;
-        for(var category in standardMessagesManager.categories.values) {
-          for(var group in category.groups.values) {
-            var messageIds = group.messages.keys;
-            if (messageIds.contains(messageData.messageId)) {
-              categoryName = category.categoryName;
-              groupName = group.groupName;
-              break;
-            }
-          }
-        }
+        var categoryName = standardMessagesManager.categories[standardMessage.categoryId].categoryName;
+        var groupName = standardMessagesManager.categories[standardMessage.categoryId].groups[standardMessage.groupId].groupName;
 
         // todo: unwanted map since we use only the category Id, group Id
         var messageCategoryMap = {

--- a/webapp/lib/app/configurator/standard_messages/controller.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller.dart
@@ -182,7 +182,7 @@ class MessagesConfiguratorController extends ConfiguratorController {
 
       case MessagesConfigAction.removeStandardMessagesGroup:
         StandardMessagesGroupData groupData = data;
-        standardMessagesManager.deleteStandardMessagesGroup(groupData.categoryId, groupData.categoryName, groupData.groupId, groupData.groupName);
+        standardMessagesManager.deleteStandardMessagesGroup(groupData.categoryId, groupData.groupId);
         _view.categoriesById[groupData.categoryId].removeGroup(groupData.groupId);
         _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
@@ -205,7 +205,7 @@ class MessagesConfiguratorController extends ConfiguratorController {
 
       case MessagesConfigAction.removeStandardMessagesCategory:
         StandardMessagesCategoryData categoryData = data;
-        standardMessagesManager.deleteStandardMessagesCategory(categoryData.categoryId, categoryData.categoryName);
+        standardMessagesManager.deleteStandardMessagesCategory(categoryData.categoryId);
         _view.categories.removeItem(categoryData.categoryId);
         _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;

--- a/webapp/lib/app/configurator/standard_messages/controller.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller.dart
@@ -96,41 +96,58 @@ class MessagesConfiguratorController extends ConfiguratorController {
       case MessagesConfigAction.addStandardMessage:
         StandardMessageData messageData = data;
         var message = standardMessagesManager.createMessage(messageData.categoryId, messageData.category, messageData.groupId, messageData.group);
-
-        _addMessagesToView({
-          message.categoryId: {
-            message.groupId: [message]
-          }
-        });
+        var messageCategoryMap = {
+          message.categoryId: MessageCategory(messageData.categoryId, messageData.category)
+            ..groups = {
+              message.groupId: MessageGroup(messageData.groupId, messageData.group)
+            }
+        };
+        _addMessagesToView(messageCategoryMap);
         _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
 
       case MessagesConfigAction.updateStandardMessage:
         StandardMessageData messageData = data;
         var standardMessage = standardMessagesManager.modifyMessage(messageData.messageId, messageData.text, messageData.translation);
-        _modifyMessagesInView({
-          standardMessage.categoryId: {
-            standardMessage.groupId: [standardMessage]
-          }
-        });
+        var messageCategoryMap = {
+          standardMessage.categoryId: MessageCategory(standardMessage.categoryId, standardMessage.category)
+            ..groups = {
+              standardMessage.groupId: MessageGroup(messageData.groupId, messageData.group)
+                ..messages = {
+                  standardMessage.docId: standardMessage
+                }
+            }
+        };
+        _modifyMessagesInView(messageCategoryMap);
         _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
 
       case MessagesConfigAction.removeStandardMessage:
         StandardMessageData messageData = data;
         var standardMessage = standardMessagesManager.deleteMessage(messageData.messageId);
-        _removeMessagesFromView({
-          standardMessage.categoryId: {
-            standardMessage.groupId: [standardMessage]
-          }
-        });
+        var messageCategoryMap = {
+          standardMessage.categoryId: MessageCategory(standardMessage.categoryId, standardMessage.category)
+            ..groups = {
+              standardMessage.groupId: MessageGroup(messageData.groupId, messageData.group)
+                ..messages = {
+                  standardMessage.docId: standardMessage
+                }
+            }
+        };
+        _removeMessagesFromView(messageCategoryMap);
         _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
 
       case MessagesConfigAction.addStandardMessagesGroup:
         StandardMessagesGroupData groupData = data;
         var newGroup = standardMessagesManager.createStandardMessagesGroup(groupData.categoryId, groupData.categoryName);
-        _addMessagesToView({groupData.categoryId: {newGroup.groupId: []}}, startEditingName: true);
+        var messageCategoryMap = {
+          groupData.categoryId: MessageCategory(groupData.categoryId, groupData.categoryName)
+            ..groups = {
+              newGroup.groupId: MessageGroup(newGroup.groupId, newGroup.groupName)
+            }
+        };
+        _addMessagesToView(messageCategoryMap, startEditingName: true);
         _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
 
@@ -150,7 +167,10 @@ class MessagesConfiguratorController extends ConfiguratorController {
 
       case MessagesConfigAction.addStandardMessagesCategory:
         var newCategory = standardMessagesManager.createStandardMessagesCategory();
-        _addMessagesToView({newCategory.categoryId: {}}, startEditingName: true);
+        var messageCategoryMap = {
+          newCategory.categoryId: MessageCategory(newCategory.categoryId, newCategory.categoryName)
+        };
+        _addMessagesToView(messageCategoryMap, startEditingName: true);
         _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
 

--- a/webapp/lib/app/configurator/standard_messages/controller.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller.dart
@@ -110,7 +110,7 @@ class MessagesConfiguratorController extends ConfiguratorController {
             }
         };
         _addMessagesToView(messageCategoryMap);
-        // _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
+        _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
 
       case MessagesConfigAction.updateStandardMessage:
@@ -140,7 +140,7 @@ class MessagesConfiguratorController extends ConfiguratorController {
             }
         };
         _modifyMessagesInView(messageCategoryMap);
-        // _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
+        _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
 
       case MessagesConfigAction.removeStandardMessage:
@@ -157,7 +157,7 @@ class MessagesConfiguratorController extends ConfiguratorController {
         };
         // todo: unwanted map since we use only the category Id, group Id
         _removeMessagesFromView(messageCategoryMap);
-        // _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
+        _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
 
       case MessagesConfigAction.addStandardMessagesGroup:
@@ -170,21 +170,21 @@ class MessagesConfiguratorController extends ConfiguratorController {
             }
         };
         _addMessagesToView(messageCategoryMap, startEditingName: true);
-        // _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
+        _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
 
       case MessagesConfigAction.updateStandardMessagesGroup:
         StandardMessagesGroupData groupData = data;
         standardMessagesManager.renameStandardMessageGroup(groupData.categoryId, groupData.categoryName, groupData.groupId, groupData.groupName, groupData.newGroupName);
         _view.categoriesById[groupData.categoryId].renameGroup(groupData.groupId, groupData.groupName, groupData.newGroupName);
-        // _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
+        _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
 
       case MessagesConfigAction.removeStandardMessagesGroup:
         StandardMessagesGroupData groupData = data;
         standardMessagesManager.deleteStandardMessagesGroup(groupData.categoryId, groupData.categoryName, groupData.groupId, groupData.groupName);
         _view.categoriesById[groupData.categoryId].removeGroup(groupData.groupId);
-        // _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
+        _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
 
       case MessagesConfigAction.addStandardMessagesCategory:
@@ -193,21 +193,21 @@ class MessagesConfiguratorController extends ConfiguratorController {
           newCategory.categoryId: MessageCategory(newCategory.categoryId, newCategory.categoryName)
         };
         _addMessagesToView(messageCategoryMap, startEditingName: true);
-        // _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
+        _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
 
       case MessagesConfigAction.updateStandardMessagesCategory:
         StandardMessagesCategoryData categoryData = data;
         standardMessagesManager.renameStandardMessageCategory(categoryData.categoryId, categoryData.categoryName, categoryData.newCategoryName);
         _view.renameCategory(categoryData.categoryId, categoryData.categoryName, categoryData.newCategoryName);
-        // _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
+        _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
 
       case MessagesConfigAction.removeStandardMessagesCategory:
         StandardMessagesCategoryData categoryData = data;
         standardMessagesManager.deleteStandardMessagesCategory(categoryData.categoryId, categoryData.categoryName);
         _view.categories.removeItem(categoryData.categoryId);
-        // _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
+        _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
     }
 

--- a/webapp/lib/app/configurator/standard_messages/controller.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller.dart
@@ -99,7 +99,6 @@ class MessagesConfiguratorController extends ConfiguratorController {
         var groupName = standardMessagesManager.categories[messageData.categoryId].groups[messageData.groupId].groupName;
 
         var message = standardMessagesManager.createMessage(messageData.categoryId, categoryName, messageData.groupId, groupName);
-        // todo: unwanted map since we use only the category Id, group Id
         var messageCategoryMap = {
           message.categoryId: MessageCategory(messageData.categoryId, categoryName)
             ..groups = {

--- a/webapp/lib/app/configurator/standard_messages/controller.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller.dart
@@ -28,39 +28,44 @@ enum MessagesConfigAction {
 }
 
 class StandardMessageData extends Data {
-  String id;
+  String messageId;
   String text;
   String translation;
+  String groupId;
   String group;
+  String categoryId;
   String category;
-  StandardMessageData(this.id, {this.text, this.translation, this.group, this.category});
+  StandardMessageData(this.messageId, {this.text, this.translation, this.groupId, this.group, this.categoryId, this.category});
 
   @override
   String toString() {
-    return "StandardMessageData($id, '$text', '$translation', $group, $category)";
+    return "StandardMessageData($messageId, '$text', '$translation', $groupId, $group, $categoryId, $category)";
   }
 }
 
 class StandardMessagesGroupData extends Data {
-  String group;
+  String groupId;
+  String groupName;
   String newGroupName;
-  String category;
-  StandardMessagesGroupData(this.category, this.group, {this.newGroupName});
+  String categoryId;
+  String categoryName;
+  StandardMessagesGroupData(this.categoryId, this.categoryName, this.groupId, this.groupName, {this.newGroupName});
 
   @override
   String toString() {
-    return "StandardMessagesGroupData($category, $group, '$newGroupName')";
+    return "StandardMessagesGroupData($categoryId, $categoryName, $groupId, $groupName, '$newGroupName')";
   }
 }
 
 class StandardMessagesCategoryData extends Data {
-  String category;
+  String categoryId;
+  String categoryName;
   String newCategoryName;
-  StandardMessagesCategoryData(this.category, {this.newCategoryName});
+  StandardMessagesCategoryData(this.categoryId, category, {this.newCategoryName});
 
   @override
   String toString() {
-    return "StandardMessagesCategoryData($category, '$newCategoryName')";
+    return "StandardMessagesCategoryData($categoryId, $categoryName, '$newCategoryName')";
   }
 }
 
@@ -90,11 +95,11 @@ class MessagesConfiguratorController extends ConfiguratorController {
     switch (action) {
       case MessagesConfigAction.addStandardMessage:
         StandardMessageData messageData = data;
-        var message = standardMessagesManager.createMessage(messageData.category, messageData.group);
+        var message = standardMessagesManager.createMessage(messageData.categoryId, messageData.category, messageData.groupId, messageData.group);
 
         _addMessagesToView({
-          message.category: {
-            message.groupDescription: [message]
+          message.categoryId: {
+            message.groupId: [message]
           }
         });
         _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
@@ -102,10 +107,10 @@ class MessagesConfiguratorController extends ConfiguratorController {
 
       case MessagesConfigAction.updateStandardMessage:
         StandardMessageData messageData = data;
-        var standardMessage = standardMessagesManager.modifyMessage(messageData.id, messageData.text, messageData.translation);
+        var standardMessage = standardMessagesManager.modifyMessage(messageData.messageId, messageData.text, messageData.translation);
         _modifyMessagesInView({
-          standardMessage.category: {
-            standardMessage.groupDescription: [standardMessage]
+          standardMessage.categoryId: {
+            standardMessage.groupId: [standardMessage]
           }
         });
         _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
@@ -113,10 +118,10 @@ class MessagesConfiguratorController extends ConfiguratorController {
 
       case MessagesConfigAction.removeStandardMessage:
         StandardMessageData messageData = data;
-        var standardMessage = standardMessagesManager.deleteMessage(messageData.id);
+        var standardMessage = standardMessagesManager.deleteMessage(messageData.messageId);
         _removeMessagesFromView({
-          standardMessage.category: {
-            standardMessage.groupDescription: [standardMessage]
+          standardMessage.categoryId: {
+            standardMessage.groupId: [standardMessage]
           }
         });
         _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
@@ -124,42 +129,42 @@ class MessagesConfiguratorController extends ConfiguratorController {
 
       case MessagesConfigAction.addStandardMessagesGroup:
         StandardMessagesGroupData groupData = data;
-        var newGroup = standardMessagesManager.createStandardMessagesGroup(groupData.category);
-        _addMessagesToView({groupData.category: {newGroup.groupDescription: []}}, startEditingName: true);
+        var newGroup = standardMessagesManager.createStandardMessagesGroup(groupData.categoryId, groupData.categoryName);
+        _addMessagesToView({groupData.categoryId: {newGroup.groupId: []}}, startEditingName: true);
         _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
 
       case MessagesConfigAction.updateStandardMessagesGroup:
         StandardMessagesGroupData groupData = data;
-        standardMessagesManager.renameStandardMessageGroup(groupData.category, groupData.group, groupData.newGroupName);
-        _view.categoriesByName[groupData.category].renameGroup(groupData.group, groupData.newGroupName);
+        standardMessagesManager.renameStandardMessageGroup(groupData.categoryId, groupData.categoryName, groupData.groupId, groupData.groupName, groupData.newGroupName);
+        _view.categoriesById[groupData.categoryId].renameGroup(groupData.groupId, groupData.groupName, groupData.newGroupName);
         _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
 
       case MessagesConfigAction.removeStandardMessagesGroup:
         StandardMessagesGroupData groupData = data;
-        standardMessagesManager.deleteStandardMessagesGroup(groupData.category, groupData.group);
-        _view.categoriesByName[groupData.category].removeGroup(groupData.group);
+        standardMessagesManager.deleteStandardMessagesGroup(groupData.categoryId, groupData.categoryName, groupData.groupId, groupData.groupName);
+        _view.categoriesById[groupData.categoryId].removeGroup(groupData.groupId);
         _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
 
       case MessagesConfigAction.addStandardMessagesCategory:
         var newCategory = standardMessagesManager.createStandardMessagesCategory();
-        _addMessagesToView({newCategory: {}}, startEditingName: true);
+        _addMessagesToView({newCategory.categoryId: {}}, startEditingName: true);
         _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
 
       case MessagesConfigAction.updateStandardMessagesCategory:
         StandardMessagesCategoryData categoryData = data;
-        standardMessagesManager.renameStandardMessageCategory(categoryData.category, categoryData.newCategoryName);
-        _view.renameCategory(categoryData.category, categoryData.newCategoryName);
+        standardMessagesManager.renameStandardMessageCategory(categoryData.categoryId, categoryData.categoryName, categoryData.newCategoryName);
+        _view.renameCategory(categoryData.categoryId, categoryData.categoryName, categoryData.newCategoryName);
         _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
 
       case MessagesConfigAction.removeStandardMessagesCategory:
         StandardMessagesCategoryData categoryData = data;
-        standardMessagesManager.deleteStandardMessagesCategory(categoryData.category);
-        _view.categories.removeItem(categoryData.category);
+        standardMessagesManager.deleteStandardMessagesCategory(categoryData.categoryId, categoryData.categoryName);
+        _view.categories.removeItem(categoryData.categoryId);
         _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
     }

--- a/webapp/lib/app/configurator/standard_messages/controller.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller.dart
@@ -165,7 +165,7 @@ class MessagesConfiguratorController extends ConfiguratorController {
         var messageCategoryMap = {
           groupData.categoryId: MessageCategory(groupData.categoryId, groupData.categoryName)
             ..groups = {
-              newGroup.groupId: MessageGroup(newGroup.groupId ?? model.generateStandardMessageGroupId(), newGroup.groupName)
+              newGroup.groupId: MessageGroup(newGroup.groupId, newGroup.groupName)
             }
         };
         _addMessagesToView(messageCategoryMap, startEditingName: true);

--- a/webapp/lib/app/configurator/standard_messages/controller.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller.dart
@@ -175,8 +175,8 @@ class MessagesConfiguratorController extends ConfiguratorController {
 
       case MessagesConfigAction.updateStandardMessagesGroup:
         StandardMessagesGroupData groupData = data;
-        standardMessagesManager.renameStandardMessageGroup(groupData.categoryId, groupData.categoryName, groupData.groupId, groupData.groupName, groupData.newGroupName);
-        _view.categoriesById[groupData.categoryId].renameGroup(groupData.groupId, groupData.groupName, groupData.newGroupName);
+        standardMessagesManager.renameStandardMessageGroup(groupData.categoryId, groupData.groupId, groupData.newGroupName);
+        _view.categoriesById[groupData.categoryId].renameGroup(groupData.groupId, groupData.newGroupName);
         _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
 
@@ -198,8 +198,8 @@ class MessagesConfiguratorController extends ConfiguratorController {
 
       case MessagesConfigAction.updateStandardMessagesCategory:
         StandardMessagesCategoryData categoryData = data;
-        standardMessagesManager.renameStandardMessageCategory(categoryData.categoryId, categoryData.categoryName, categoryData.newCategoryName);
-        _view.renameCategory(categoryData.categoryId, categoryData.categoryName, categoryData.newCategoryName);
+        standardMessagesManager.renameStandardMessageCategory(categoryData.categoryId, categoryData.newCategoryName);
+        _view.renameCategory(categoryData.categoryId, categoryData.newCategoryName);
         _updateUnsavedIndicators(standardMessagesManager.categories, standardMessagesManager.unsavedMessageIds, standardMessagesManager.unsavedGroupIds, standardMessagesManager.unsavedCategoryIds);
         break;
 

--- a/webapp/lib/app/configurator/standard_messages/controller_messages_helper.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller_messages_helper.dart
@@ -189,8 +189,8 @@ class StandardMessagesManager {
 
   /// The message IDs that are arrived from editedMessages, deletedMessages
   Set<String> get unsavedMessageIds => editedMessages.entries.map((e) => e.value.docId).toSet()..addAll(deletedMessages.entries.map((e) => e.value.docId).toSet());
-  Set<String> get unsavedGroupIds => editedMessages.entries.map((e) => e.value.groupDescription).toSet()..addAll(deletedMessages.entries.map((e) => e.value.groupDescription).toSet());
-  Set<String> get unsavedCategoryIds => editedMessages.entries.map((e) => e.value.category).toSet()..addAll(deletedMessages.entries.map((e) => e.value.category).toSet());
+  Set<String> get unsavedGroupIds => editedMessages.entries.map((e) => e.value.groupId).toSet()..addAll(deletedMessages.entries.map((e) => e.value.groupId).toSet());
+  Set<String> get unsavedCategoryIds => editedMessages.entries.map((e) => e.value.categoryId).toSet()..addAll(deletedMessages.entries.map((e) => e.value.categoryId).toSet());
 
   /// Returns whether there's any edited or deleted messages to be saved.
   bool get hasUnsavedMessages => editedMessages.isNotEmpty || deletedMessages.isNotEmpty;

--- a/webapp/lib/app/configurator/standard_messages/controller_messages_helper.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller_messages_helper.dart
@@ -137,7 +137,7 @@ class StandardMessagesManager {
     return newMessageGroup;
   }
 
-  void renameStandardMessageGroup(String categoryId, String category, String groupId, String groupName, String newGroupName) {
+  void renameStandardMessageGroup(String categoryId, String groupId, String newGroupName) {
     var group = categories[categoryId].groups.remove(groupId); // todo: why remove?
     group.groupName = newGroupName;
     for (var standardMessage in group.messages.values) {
@@ -164,7 +164,7 @@ class StandardMessagesManager {
 
   /// Renames a messages category and propagates the change to all the messages in that category.
   /// Also adds these messages to the list of messages that have been edited and need to be saved.
-  void renameStandardMessageCategory(String categoryId, String categoryName, String newCategoryName) {
+  void renameStandardMessageCategory(String categoryId, String newCategoryName) {
     var category = categories.remove(categoryId);  // todo: why remove?
     category.categoryName = newCategoryName;
     for (var standardMessage in category.messages) {

--- a/webapp/lib/app/configurator/standard_messages/controller_messages_helper.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller_messages_helper.dart
@@ -147,7 +147,7 @@ class StandardMessagesManager {
     categories[categoryId].groups[groupId] = group;
   }
 
-  void deleteStandardMessagesGroup(String categoryId, String category, String groupId, String groupDescription) {
+  void deleteStandardMessagesGroup(String categoryId, String groupId) {
     var group = categories[categoryId].groups.remove(groupId);
     deletedMessages.addAll(group.messages);
   }
@@ -176,7 +176,7 @@ class StandardMessagesManager {
 
   /// Deletes the messages category with the given [categoryName], and the messages in that category.
   /// Also adds these messages to the list of messages to be deleted and need to be saved.
-  void deleteStandardMessagesCategory(String categoryId, String categoryName) {
+  void deleteStandardMessagesCategory(String categoryId) {
     var category = categories.remove(categoryId);
     deletedMessages.addEntries(category.messages.map((e) => MapEntry(e.suggestedReplyId, e)));
   }

--- a/webapp/lib/app/configurator/standard_messages/controller_messages_helper.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller_messages_helper.dart
@@ -138,13 +138,12 @@ class StandardMessagesManager {
   }
 
   void renameStandardMessageGroup(String categoryId, String groupId, String newGroupName) {
-    var group = categories[categoryId].groups.remove(groupId); // todo: why remove?
+    var group = categories[categoryId].groups[groupId];
     group.groupName = newGroupName;
     for (var standardMessage in group.messages.values) {
       standardMessage.groupDescription = newGroupName;
       editedMessages[standardMessage.suggestedReplyId] = standardMessage;
     }
-    categories[categoryId].groups[groupId] = group;
   }
 
   void deleteStandardMessagesGroup(String categoryId, String groupId) {
@@ -165,13 +164,12 @@ class StandardMessagesManager {
   /// Renames a messages category and propagates the change to all the messages in that category.
   /// Also adds these messages to the list of messages that have been edited and need to be saved.
   void renameStandardMessageCategory(String categoryId, String newCategoryName) {
-    var category = categories.remove(categoryId);  // todo: why remove?
+    var category = categories[categoryId];
     category.categoryName = newCategoryName;
     for (var standardMessage in category.messages) {
       standardMessage.category = newCategoryName;
       editedMessages[standardMessage.suggestedReplyId] = standardMessage;
     }
-    categories[categoryId] = category;
   }
 
   /// Deletes the messages category with the given [categoryName], and the messages in that category.

--- a/webapp/lib/app/configurator/standard_messages/controller_view_helper.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller_view_helper.dart
@@ -80,7 +80,6 @@ Map<String, MessageCategory> _groupMessagesIntoCategoriesAndGroups(List<model.Su
     result[message.categoryId].groups.putIfAbsent(message.groupId, () => MessageGroup(message.groupId, message.groupDescription));
     result[message.categoryId].groups[message.groupId].messages.putIfAbsent(message.docId, () => message);
   }
-  // todo: bring back the sequence number
   for (String category in result.keys) {
     for (String group in result[category].groups.keys) {
       // TODO (mariana): once we've transitioned to using groups, we can remove the sequence number comparison

--- a/webapp/lib/app/configurator/standard_messages/controller_view_helper.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller_view_helper.dart
@@ -81,11 +81,11 @@ Map<String, MessageCategory> _groupMessagesIntoCategoriesAndGroups(List<model.Su
     result[message.categoryId].groups[message.groupId].messages.putIfAbsent(message.docId, () => message);
   }
   // todo: bring back the sequence number
-  // for (String category in result.keys) {
-  //   for (String group in result[category].keys) {
-  //     // TODO (mariana): once we've transitioned to using groups, we can remove the sequence number comparison
-  //     result[category][group].sort((message1, message2) => (message1.indexInGroup ?? message1.seqNumber).compareTo(message2.indexInGroup ?? message2.seqNumber));
-  //   }
-  // }
+  for (String category in result.keys) {
+    for (String group in result[category].groups.keys) {
+      // TODO (mariana): once we've transitioned to using groups, we can remove the sequence number comparison
+      result[category].groups[group].messages.values.toList().sort((message1, message2) => (message1.indexInGroup ?? message1.seqNumber).compareTo(message2.indexInGroup ?? message2.seqNumber));
+    }
+  }
   return result;
 }

--- a/webapp/lib/app/configurator/standard_messages/controller_view_helper.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller_view_helper.dart
@@ -83,7 +83,7 @@ Map<String, MessageCategory> _groupMessagesIntoCategoriesAndGroups(List<model.Su
   for (String category in result.keys) {
     for (String group in result[category].groups.keys) {
       // TODO (mariana): once we've transitioned to using groups, we can remove the sequence number comparison
-      result[category].groups[group].messages.values.toList().sort((message1, message2) => (message1.indexInGroup ?? message1.seqNumber).compareTo(message2.indexInGroup ?? message2.seqNumber));
+      result[category].groups[group].messages.values.toList().sort((message1, message2) => (message1.indexInGroup).compareTo(message2.indexInGroup));
     }
   }
   return result;

--- a/webapp/lib/app/configurator/standard_messages/controller_view_helper.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller_view_helper.dart
@@ -1,26 +1,26 @@
 part of controller;
 
 void _addMessagesToView(Map<String, Map<String, List<model.SuggestedReply>>> messagesByGroupByCategory, {bool startEditingName = false}) {
-  for (var category in messagesByGroupByCategory.keys.toList()) {
-    if (_view.categories.queryItem(category) == null) {
-      _view.addCategory(category, new StandardMessagesCategoryView(category, DivElement(), DivElement()));
+  for (var categoryId in messagesByGroupByCategory.keys.toList()) {
+    if (_view.categories.queryItem(categoryId) == null) {
+      _view.addCategory(categoryId, new StandardMessagesCategoryView(categoryId, "asd", DivElement(), DivElement())); // todo: implication of this?
       if (startEditingName) {
-        _view.categoriesByName[category].expand();
-        _view.categoriesByName[category].editableTitle.beginEdit(selectAllOnFocus: true);
+        _view.categoriesById[categoryId].expand();
+        _view.categoriesById[categoryId].editableTitle.beginEdit(selectAllOnFocus: true);
       }
     }
-    var categoryView = _view.categoriesByName[category];
+    var categoryView = _view.categoriesById[categoryId];
     int groupIndex = 0;
-    for (var group in messagesByGroupByCategory[category].keys.toList()..sort()) {
-      if (categoryView.groups.queryItem(group) == null) {
-        categoryView.addGroup(group, new StandardMessagesGroupView(category, group, DivElement(), DivElement()), groupIndex);
+    for (var groupId in messagesByGroupByCategory[categoryId].keys.toList()..sort()) {
+      if (categoryView.groups.queryItem(groupId) == null) {
+        categoryView.addGroup(groupId, new StandardMessagesGroupView(categoryId, 'asd', groupId, 'dsa', DivElement(), DivElement()), groupIndex); // todo: implication of this?
         if (startEditingName) {
-          categoryView.groupsByName[group].expand();
-          categoryView.groupsByName[group].editableTitle.beginEdit(selectAllOnFocus: true);
+          categoryView.groupsById[groupId].expand();
+          categoryView.groupsById[groupId].editableTitle.beginEdit(selectAllOnFocus: true);
         }
       }
-      var groupView = categoryView.groupsByName[group];
-      for (var message in messagesByGroupByCategory[category][group]) {
+      var groupView = categoryView.groupsById[groupId];
+      for (var message in messagesByGroupByCategory[categoryId][groupId]) {
         groupView.addMessage(message.suggestedReplyId, new StandardMessageView(message.suggestedReplyId, message.text, message.translation));
       }
       groupIndex++;
@@ -29,11 +29,11 @@ void _addMessagesToView(Map<String, Map<String, List<model.SuggestedReply>>> mes
 }
 
 void _removeMessagesFromView(Map<String, Map<String, List<model.SuggestedReply>>> messagesByGroupByCategory) {
-  for (var category in messagesByGroupByCategory.keys.toList()) {
-    var categoryView = _view.categoriesByName[category];
-    for (var group in messagesByGroupByCategory[category].keys.toList()) {
-      var groupView = categoryView.groupsByName[group];
-      for (var message in messagesByGroupByCategory[category][group]) {
+  for (var categoryId in messagesByGroupByCategory.keys.toList()) {
+    var categoryView = _view.categoriesById[categoryId];
+    for (var groupId in messagesByGroupByCategory[categoryId].keys.toList()) {
+      var groupView = categoryView.groupsById[groupId];
+      for (var message in messagesByGroupByCategory[categoryId][groupId]) {
         groupView.removeMessage(message.suggestedReplyId);
       }
     }
@@ -41,11 +41,11 @@ void _removeMessagesFromView(Map<String, Map<String, List<model.SuggestedReply>>
 }
 
 void _modifyMessagesInView(Map<String, Map<String, List<model.SuggestedReply>>> messagesByGroupByCategory) {
-  for (var category in messagesByGroupByCategory.keys.toList()) {
-    var categoryView = _view.categoriesByName[category];
-    for (var group in messagesByGroupByCategory[category].keys.toList()) {
-      var groupView = categoryView.groupsByName[group];
-      for (var message in messagesByGroupByCategory[category][group]) {
+  for (var categoryId in messagesByGroupByCategory.keys.toList()) {
+    var categoryView = _view.categoriesById[categoryId];
+    for (var groupId in messagesByGroupByCategory[categoryId].keys.toList()) {
+      var groupView = categoryView.groupsById[groupId];
+      for (var message in messagesByGroupByCategory[categoryId][groupId]) {
         var messageView = new StandardMessageView(message.suggestedReplyId, message.text, message.translation);
         groupView.modifyMessage(message.suggestedReplyId, messageView);
       }
@@ -54,17 +54,17 @@ void _modifyMessagesInView(Map<String, Map<String, List<model.SuggestedReply>>> 
 }
 
 void _updateUnsavedIndicators(Map<String, MessageCategory> categories, Set<String> unsavedMessageIds, Set<String> unsavedGroupIds, Set<String> unsavedCategoryIds) {
-  for (var category in categories.keys) {
-    var categoryView = _view.categoriesByName[category];
-    categoryView.markAsUnsaved(unsavedCategoryIds.contains(category));
+  for (var categoryId in categories.keys) {
+    var categoryView = _view.categoriesById[categoryId];
+    categoryView.markAsUnsaved(unsavedCategoryIds.contains(categoryId));
 
-    for (var group in categories[category].groups.keys) {
-      var groupView = categoryView.groupsByName[group];
-      groupView.markAsUnsaved(unsavedGroupIds.contains(group));
+    for (var groupId in categories[categoryId].groups.keys) {
+      var groupView = categoryView.groupsById[groupId];
+      groupView.markAsUnsaved(unsavedGroupIds.contains(groupId));
 
-      for (var message in categories[category].groups[group].messages.keys) {
-        var messageView = groupView.messagesById[message];
-        messageView.markAsUnsaved(unsavedMessageIds.contains(message));
+      for (var messageId in categories[categoryId].groups[groupId].messages.keys) {
+        var messageView = groupView.messagesById[messageId];
+        messageView.markAsUnsaved(unsavedMessageIds.contains(messageId));
       }
     }
   }

--- a/webapp/lib/app/configurator/standard_messages/view.dart
+++ b/webapp/lib/app/configurator/standard_messages/view.dart
@@ -43,7 +43,7 @@ class MessagesConfigurationPageView extends ConfigurationPageView {
     categoriesById[categoryId] = categoryView;
   }
 
-  void renameCategory(String categoryId, String categoryName, String newCategoryName) {
+  void renameCategory(String categoryId, String newCategoryName) {
     var categoryView = _view.categoriesById.remove(categoryId); // why remove?
     categoryView.id = categoryId;
     categoryView.name = newCategoryName;
@@ -126,7 +126,7 @@ class StandardMessagesCategoryView extends AccordionItem {
     groupsById[groupId] = standardMessagesGroupView;
   }
 
-  void renameGroup(String groupId, String groupName, String newGroupName) {
+  void renameGroup(String groupId, String newGroupName) {
     var groupView = groupsById.remove(groupId);
     // groupView.id = newGroupName;
     groupsById[groupId] = groupView;

--- a/webapp/lib/app/configurator/standard_messages/view.dart
+++ b/webapp/lib/app/configurator/standard_messages/view.dart
@@ -44,7 +44,7 @@ class MessagesConfigurationPageView extends ConfigurationPageView {
   }
 
   void renameCategory(String categoryId, String categoryName, String newCategoryName) {
-    var categoryView = _view.categoriesById.remove(categoriesById); // why remove?
+    var categoryView = _view.categoriesById.remove(categoryId); // why remove?
     categoryView.id = categoryId;
     categoryView.name = newCategoryName;
     categoriesById[categoryId] = categoryView;
@@ -84,7 +84,7 @@ class StandardMessagesCategoryView extends AccordionItem {
 
   Map<String, StandardMessagesGroupView> groupsById = {};
 
-  StandardMessagesCategoryView(String this._categoryId, this._categoryName, DivElement header, DivElement body) : super(_categoryName, header, body, false) {
+  StandardMessagesCategoryView(String this._categoryId, this._categoryName, DivElement header, DivElement body) : super(_categoryId, header, body, false) {
     _categoryName = _categoryName ?? '';
 
     editableTitle = TextEdit(_categoryName, removable: true)
@@ -109,7 +109,7 @@ class StandardMessagesCategoryView extends AccordionItem {
     groups = new Accordion([]);
     _standardMessagesGroupContainer.append(groups.renderElement);
 
-    _addButton = Button(ButtonType.add, hoverText: 'Add a new group of standard messages', onClick: (event) => _view.appController.command(MessagesConfigAction.addStandardMessagesGroup, new StandardMessagesGroupData(_categoryId, _categoryName, null, '')));
+    _addButton = Button(ButtonType.add, hoverText: 'Add a new group of standard messages', onClick: (event) => _view.appController.command(MessagesConfigAction.addStandardMessagesGroup, new StandardMessagesGroupData(_categoryId, _categoryName, null, 'New group')));
 
     body.append(_addButton.renderElement);
   }
@@ -130,7 +130,7 @@ class StandardMessagesCategoryView extends AccordionItem {
     var groupView = groupsById.remove(groupId);
     // groupView.id = newGroupName;
     groupsById[groupId] = groupView;
-    groups.updateItem(newGroupName, groupView);
+    groups.updateItem(groupId, groupView);
   }
 
   void removeGroup(String groupName) {
@@ -166,7 +166,7 @@ class StandardMessagesGroupView extends AccordionItem {
 
   Map<String, StandardMessageView> messagesById = {};
 
-  StandardMessagesGroupView(this._categoryId, this._categoryName, this._groupId, this._groupName, DivElement header, DivElement body) : super(_groupName, header, body, false) {
+  StandardMessagesGroupView(this._categoryId, this._categoryName, this._groupId, this._groupName, DivElement header, DivElement body) : super(_groupId, header, body, false) {
     editableTitle = TextEdit(_groupName, removable: true)
       ..testInput = (String value) {
         var messageManager = (_view.appController as MessagesConfiguratorController).standardMessagesManager;
@@ -187,7 +187,7 @@ class StandardMessagesGroupView extends AccordionItem {
 
     _addButton = Button(ButtonType.add);
     _addButton.renderElement.onClick.listen((e) {
-      _view.appController.command(MessagesConfigAction.addStandardMessage, new StandardMessageData('', groupId: _groupId, categoryId: _categoryId));
+      _view.appController.command(MessagesConfigAction.addStandardMessage, new StandardMessageData(null, groupId: _groupId, categoryId: _categoryId));
     });
 
     body.append(_addButton.renderElement);

--- a/webapp/lib/app/configurator/standard_messages/view.dart
+++ b/webapp/lib/app/configurator/standard_messages/view.dart
@@ -44,9 +44,10 @@ class MessagesConfigurationPageView extends ConfigurationPageView {
   }
 
   void renameCategory(String categoryId, String newCategoryName) {
-    var categoryView = _view.categoriesById.remove(categoryId); // why remove?
-    categoryView.id = categoryId;
-    categoryView.name = newCategoryName;
+    var categoryView = _view.categoriesById[categoryId];
+    categoryView
+      ..id = categoryId
+      ..name = newCategoryName;
     categoriesById[categoryId] = categoryView;
     categories.updateItem(categoryId, categoryView);
   }
@@ -127,8 +128,8 @@ class StandardMessagesCategoryView extends AccordionItem {
   }
 
   void renameGroup(String groupId, String newGroupName) {
-    var groupView = groupsById.remove(groupId);
-    // groupView.id = newGroupName;
+    var groupView = groupsById[groupId];
+    groupView._groupName = newGroupName;
     groupsById[groupId] = groupView;
     groups.updateItem(groupId, groupView);
   }
@@ -224,6 +225,8 @@ class StandardMessagesGroupView extends AccordionItem {
   void markAsUnsaved(bool unsaved) {
     editableTitle.renderElement.classes.toggle("unsaved", unsaved);
   }
+
+  // todo: add a message to reflect group name change
 }
 
 class StandardMessageView {

--- a/webapp/lib/app/configurator/standard_messages/view.dart
+++ b/webapp/lib/app/configurator/standard_messages/view.dart
@@ -21,7 +21,7 @@ class MessagesConfigurationPageView extends ConfigurationPageView {
 
   Accordion categories;
 
-  Map<String, StandardMessagesCategoryView> categoriesByName = {};
+  Map<String, StandardMessagesCategoryView> categoriesById = {};
 
   MessagesConfigurationPageView(MessagesConfiguratorController controller) : super(controller) {
     _view = this;
@@ -38,22 +38,22 @@ class MessagesConfigurationPageView extends ConfigurationPageView {
     configurationContent.append(_addButton.renderElement);
   }
 
-  void addCategory(String category, StandardMessagesCategoryView categoryView) {
+  void addCategory(String categoryId, StandardMessagesCategoryView categoryView) {
     categories.appendItem(categoryView);
-    categoriesByName[category] = categoryView;
+    categoriesById[categoryId] = categoryView;
   }
 
-  void renameCategory(String categoryName, String newCategoryName) {
-    var categoryView = _view.categoriesByName.remove(categoryName);
-    categoryView.id = newCategoryName;
+  void renameCategory(String categoryId, String categoryName, String newCategoryName) {
+    var categoryView = _view.categoriesById.remove(categoriesById); // why remove?
+    categoryView.id = categoryId;
     categoryView.name = newCategoryName;
-    categoriesByName[newCategoryName] = categoryView;
-    categories.updateItem(newCategoryName, categoryView);
+    categoriesById[categoryId] = categoryView;
+    categories.updateItem(categoryId, categoryView);
   }
 
-  void removeCategory(String category) {
-    categories.removeItem(category);
-    categoriesByName.remove(category);
+  void removeCategory(String categoryId) {
+    categories.removeItem(categoryId);
+    categoriesById.remove(categoryId);
   }
 
   void clear() {
@@ -61,12 +61,12 @@ class MessagesConfigurationPageView extends ConfigurationPageView {
   }
 
   void clearUnsavedIndicators() {
-    categoriesByName.keys.forEach((categoryName) {
-      categoriesByName[categoryName].markAsUnsaved(false);
-      categoriesByName[categoryName].groupsByName.keys.forEach((groupName) {
-        categoriesByName[categoryName].groupsByName[groupName].markAsUnsaved(false);
-        categoriesByName[categoryName].groupsByName[groupName].messagesById.keys.forEach((messageId) {
-          categoriesByName[categoryName].groupsByName[groupName].messagesById[messageId].markAsUnsaved(false);
+    categoriesById.keys.forEach((categoryId) {
+      categoriesById[categoryId].markAsUnsaved(false);
+      categoriesById[categoryId].groupsById.keys.forEach((groupId) {
+        categoriesById[categoryId].groupsById[groupId].markAsUnsaved(false);
+        categoriesById[categoryId].groupsById[groupId].messagesById.keys.forEach((messageId) {
+          categoriesById[categoryId].groupsById[groupId].messagesById[messageId].markAsUnsaved(false);
         });
       });
     });
@@ -74,6 +74,7 @@ class MessagesConfigurationPageView extends ConfigurationPageView {
 }
 
 class StandardMessagesCategoryView extends AccordionItem {
+  String _categoryId;
   String _categoryName;
   DivElement _standardMessagesGroupContainer;
   Button _addButton;
@@ -81,9 +82,9 @@ class StandardMessagesCategoryView extends AccordionItem {
 
   Accordion groups;
 
-  Map<String, StandardMessagesGroupView> groupsByName = {};
+  Map<String, StandardMessagesGroupView> groupsById = {};
 
-  StandardMessagesCategoryView(this._categoryName, DivElement header, DivElement body) : super(_categoryName, header, body, false) {
+  StandardMessagesCategoryView(String this._categoryId, this._categoryName, DivElement header, DivElement body) : super(_categoryName, header, body, false) {
     _categoryName = _categoryName ?? '';
 
     editableTitle = TextEdit(_categoryName, removable: true)
@@ -94,7 +95,7 @@ class StandardMessagesCategoryView extends AccordionItem {
         return !categories.contains(value);
       }
       ..onEdit = (value) {
-        _view.appController.command(MessagesConfigAction.updateStandardMessagesCategory, new StandardMessagesCategoryData(_categoryName, newCategoryName: value));
+        _view.appController.command(MessagesConfigAction.updateStandardMessagesCategory, new StandardMessagesCategoryData(_categoryId, _categoryName, newCategoryName: value));
         _categoryName = value;
       }
       ..onDelete = () {
@@ -108,7 +109,7 @@ class StandardMessagesCategoryView extends AccordionItem {
     groups = new Accordion([]);
     _standardMessagesGroupContainer.append(groups.renderElement);
 
-    _addButton = Button(ButtonType.add, hoverText: 'Add a new group of standard messages', onClick: (event) => _view.appController.command(MessagesConfigAction.addStandardMessagesGroup, new StandardMessagesGroupData(_categoryName, '')));
+    _addButton = Button(ButtonType.add, hoverText: 'Add a new group of standard messages', onClick: (event) => _view.appController.command(MessagesConfigAction.addStandardMessagesGroup, new StandardMessagesGroupData(_categoryId, _categoryName, null, '')));
 
     body.append(_addButton.renderElement);
   }
@@ -116,30 +117,30 @@ class StandardMessagesCategoryView extends AccordionItem {
   void set name(String value) => _categoryName = value;
   String get name => _categoryName;
 
-  void addGroup(String groupName, StandardMessagesGroupView standardMessagesGroupView, [int index]) {
+  void addGroup(String groupId, StandardMessagesGroupView standardMessagesGroupView, [int index]) {
     if (index == null || groups.items.length == index) {
       groups.appendItem(standardMessagesGroupView);
     } else {
       groups.insertItem(standardMessagesGroupView, index);
     }
-    groupsByName[groupName] = standardMessagesGroupView;
+    groupsById[groupId] = standardMessagesGroupView;
   }
 
-  void renameGroup(String groupName, String newGroupName) {
-    var groupView = groupsByName.remove(groupName);
-    groupView.id = newGroupName;
-    groupsByName[newGroupName] = groupView;
+  void renameGroup(String groupId, String groupName, String newGroupName) {
+    var groupView = groupsById.remove(groupId);
+    // groupView.id = newGroupName;
+    groupsById[groupId] = groupView;
     groups.updateItem(newGroupName, groupView);
   }
 
   void removeGroup(String groupName) {
-    groupsByName[groupName].renderElement.remove();
-    groupsByName.remove(groupName);
+    groupsById[groupName].renderElement.remove();
+    groupsById.remove(groupName);
   }
 
   void requestToDelete() {
     expand();
-    var standardMessagesCategoryData = new StandardMessagesCategoryData(id);
+    var standardMessagesCategoryData = new StandardMessagesCategoryData(_categoryId, _categoryName);
     var removeWarningModal;
     removeWarningModal = new InlineOverlayModal('Are you sure you want to remove this category?', [
         new Button(ButtonType.text,
@@ -155,15 +156,18 @@ class StandardMessagesCategoryView extends AccordionItem {
 }
 
 class StandardMessagesGroupView extends AccordionItem {
+  String _categoryId;
   String _categoryName;
+  String _groupId;
+  String _groupName;
   DivElement _standardMessagesContainer;
   Button _addButton;
   TextEdit editableTitle;
 
   Map<String, StandardMessageView> messagesById = {};
 
-  StandardMessagesGroupView(this._categoryName, String groupName, DivElement header, DivElement body) : super(groupName, header, body, false) {
-    editableTitle = TextEdit(groupName, removable: true)
+  StandardMessagesGroupView(this._categoryId, this._categoryName, this._groupId, this._groupName, DivElement header, DivElement body) : super(_groupName, header, body, false) {
+    editableTitle = TextEdit(_groupName, removable: true)
       ..testInput = (String value) {
         var messageManager = (_view.appController as MessagesConfiguratorController).standardMessagesManager;
         var groups = messageManager.standardMessages.map((e) => e.group_description).toSet();
@@ -171,7 +175,7 @@ class StandardMessagesGroupView extends AccordionItem {
         return !groups.contains(value);
       }
       ..onEdit = (value) {
-        _view.appController.command(MessagesConfigAction.updateStandardMessagesGroup, new StandardMessagesGroupData(_categoryName, id, newGroupName: value));
+        _view.appController.command(MessagesConfigAction.updateStandardMessagesGroup, new StandardMessagesGroupData(_categoryId, _categoryName, _groupId, _groupName, newGroupName: value));
       }
       ..onDelete = () {
         requestToDelete();
@@ -183,31 +187,31 @@ class StandardMessagesGroupView extends AccordionItem {
 
     _addButton = Button(ButtonType.add);
     _addButton.renderElement.onClick.listen((e) {
-      _view.appController.command(MessagesConfigAction.addStandardMessage, new StandardMessageData('', group: id, category: _categoryName));
+      _view.appController.command(MessagesConfigAction.addStandardMessage, new StandardMessageData('', groupId: _groupId, categoryId: _categoryId));
     });
 
     body.append(_addButton.renderElement);
   }
 
-  void addMessage(String id, StandardMessageView standardMessageView) {
+  void addMessage(String messageId, StandardMessageView standardMessageView) {
     _standardMessagesContainer.append(standardMessageView.renderElement);
-    messagesById[id] = standardMessageView;
+    messagesById[messageId] = standardMessageView;
   }
 
-  void modifyMessage(String id, StandardMessageView standardMessageView) {
-    _standardMessagesContainer.insertBefore(standardMessageView.renderElement, messagesById[id].renderElement);
-    messagesById[id].renderElement.remove();
-    messagesById[id] = standardMessageView;
+  void modifyMessage(String messageId, StandardMessageView standardMessageView) {
+    _standardMessagesContainer.insertBefore(standardMessageView.renderElement, messagesById[messageId].renderElement);
+    messagesById[messageId].renderElement.remove();
+    messagesById[messageId] = standardMessageView;
   }
 
-  void removeMessage(String id) {
-    messagesById[id].renderElement.remove();
-    messagesById.remove(id);
+  void removeMessage(String messageId) {
+    messagesById[messageId].renderElement.remove();
+    messagesById.remove(messageId);
   }
 
   void requestToDelete() {
     expand();
-    var standardMessagesGroupData = new StandardMessagesGroupData(_categoryName, id);
+    var standardMessagesGroupData = new StandardMessagesGroupData(_categoryId, _categoryName, _groupId, _groupName);
     var removeWarningModal;
     removeWarningModal = new InlineOverlayModal('Are you sure you want to remove this group?', [
         new Button(ButtonType.text,
@@ -225,13 +229,13 @@ class StandardMessagesGroupView extends AccordionItem {
 class StandardMessageView {
   Element _standardMessageElement;
 
-  StandardMessageView(String id, String text, String translation) {
+  StandardMessageView(String messageId, String text, String translation) {
     _standardMessageElement = new DivElement()
       ..classes.add('standard-message')
-      ..dataset['id'] = '$id';
+      ..dataset['id'] = '$messageId';
 
-    var textView = new MessageView(text, (text) => _view.appController.command(MessagesConfigAction.updateStandardMessage, new StandardMessageData(id, text: text)));
-    var translationView = new MessageView(translation, (translation) => _view.appController.command(MessagesConfigAction.updateStandardMessage, new StandardMessageData(id, translation: translation)), placeholder: '(optional) Translate the message in a secondary language here');
+    var textView = new MessageView(text, (text) => _view.appController.command(MessagesConfigAction.updateStandardMessage, new StandardMessageData(messageId, text: text)));
+    var translationView = new MessageView(translation, (translation) => _view.appController.command(MessagesConfigAction.updateStandardMessage, new StandardMessageData(messageId, translation: translation)), placeholder: '(optional) Translate the message in a secondary language here');
     _standardMessageElement
       ..append(textView.renderElement)
       ..append(translationView.renderElement);
@@ -241,7 +245,7 @@ class StandardMessageView {
       var removeWarningModal;
       removeWarningModal = new InlineOverlayModal('Are you sure you want to remove this message?', [
         new Button(ButtonType.text,
-            buttonText: 'Yes', onClick: (_) => _view.appController.command(MessagesConfigAction.removeStandardMessage, new StandardMessageData(id))),
+            buttonText: 'Yes', onClick: (_) => _view.appController.command(MessagesConfigAction.removeStandardMessage, new StandardMessageData(messageId))),
         new Button(ButtonType.text, buttonText: 'No', onClick: (_) => removeWarningModal.remove()),
       ]);
       removeWarningModal.parent = _standardMessageElement;

--- a/webapp/lib/app/configurator/tags/controller_tag_helper.dart
+++ b/webapp/lib/app/configurator/tags/controller_tag_helper.dart
@@ -208,7 +208,6 @@ class TagManager {
   /// Getters for unsaved tag Ids, group Ids derived from editedTags, deletedTags
   Set<String> get unsavedTagIds => Set.from(List.from(editedTags.keys)..addAll(deletedTags.keys));
   Set<String> get unsavedGroupIds {
-    window.console.error(movedFromGroupIds);
     var editedTagGroups = editedTags.values.map((tag) => tag.groups).expand((e) => e); //.toList();
     var deletedTagGroups = deletedTags.values.map((tag) => tag.groups).expand((e) => e); //.toList();
     Set<String> setString = Set.from(List.from(editedTagGroups)..addAll(deletedTagGroups))..addAll(movedFromGroupIds);

--- a/webapp/pubspec.lock
+++ b/webapp/pubspec.lock
@@ -264,8 +264,8 @@ packages:
     dependency: "direct main"
     description:
       path: ui
-      ref: d29152e1b7927758d06203bc0509f4837b4acf4d
-      resolved-ref: d29152e1b7927758d06203bc0509f4837b4acf4d
+      ref: d8a78015e650d2ba3166145b597826ec6fca45a0
+      resolved-ref: d8a78015e650d2ba3166145b597826ec6fca45a0
       url: "git@github.com:larksystems/katikati_common_lib.git"
     source: git
     version: "0.0.1"

--- a/webapp/pubspec.yaml
+++ b/webapp/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     git:
       url: git@github.com:larksystems/katikati_common_lib.git
       path: ui
-      ref: d29152e1b7927758d06203bc0509f4837b4acf4d
+      ref: d8a78015e650d2ba3166145b597826ec6fca45a0
 
 dev_dependencies:
   build_runner: ^1.7.0


### PR DESCRIPTION
Main DS changes
`MessageCategory` under `controller_messages_helper.dart` now takes in categoryName
`categories` under `StandardMessagesManager` is not a simple map of <String(categoryName), String(groupName), ...SuggestedReplies> but`<String(categoryId), MessageCategory>` hence we would be using categories[categoryId]._groups_[groupId]._messages_[messageId] / constructing this new data type for update/render methods


- Renamed `id` to be of messageId / groupId / categoryId where applicable for easier comprehension
- Changed all the maps to use Id instead of Name for both category / group
- Removed 2 unused methods related to `sequenceNumber`