### PR TITLE
Fix for bugs in standard messages page

### DIFF
--- a/webapp/lib/app/configurator/standard_messages/controller.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller.dart
@@ -133,9 +133,7 @@ class MessagesConfiguratorController extends ConfiguratorController {
 
       case MessagesConfigAction.resetStandardMessageText:
         StandardMessageData messageData = data;
-        var message = standardMessagesManager.standardMessagesInStorage.firstWhere((element) => element.docId == messageData.messageId, orElse: () {
-          return null;
-        },);
+        var message = standardMessagesManager.standardMessagesInStorage.firstWhere((element) => element.docId == messageData.messageId, orElse: () => null);
         if (message == null) {
           var localMessage = standardMessagesManager.standardMessagesInLocal.firstWhere((element) => element.docId == messageData.messageId);
           var translation = localMessage.translation;
@@ -151,9 +149,7 @@ class MessagesConfiguratorController extends ConfiguratorController {
 
       case MessagesConfigAction.resetStandardMessageTranslation:
         StandardMessageData messageData = data;
-        var message = standardMessagesManager.standardMessagesInStorage.firstWhere((element) => element.docId == messageData.messageId, orElse: () {
-          return null;
-        });
+        var message = standardMessagesManager.standardMessagesInStorage.firstWhere((element) => element.docId == messageData.messageId, orElse: () => null);
         if (message == null) {
           var localMessage = standardMessagesManager.standardMessagesInLocal.firstWhere((element) => element.docId == messageData.messageId);
           var textToReset = localMessage.text;

--- a/webapp/lib/app/configurator/standard_messages/controller.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller.dart
@@ -133,7 +133,16 @@ class MessagesConfiguratorController extends ConfiguratorController {
 
       case MessagesConfigAction.resetStandardMessageText:
         StandardMessageData messageData = data;
-        var message = standardMessagesManager.standardMessagesInStorage.firstWhere((element) => element.docId == messageData.messageId);
+        var message = standardMessagesManager.standardMessagesInStorage.firstWhere((element) => element.docId == messageData.messageId, orElse: () {
+          return null;
+        },);
+        if (message == null) {
+          var localMessage = standardMessagesManager.standardMessagesInLocal.firstWhere((element) => element.docId == messageData.messageId);
+          var translation = localMessage.translation;
+          var standardMessage = standardMessagesManager.modifyMessage(messageData.messageId, "", translation);
+          _modifyMessagesInView([standardMessage]);
+          break;
+        }
         var textToReset = standardMessagesManager.storageCategories[message.categoryId].groups[message.groupId].messages[message.docId].text;
         var translation = standardMessagesManager.localCategories[message.categoryId].groups[message.groupId].messages[message.docId].translation;
         var standardMessage = standardMessagesManager.modifyMessage(messageData.messageId, textToReset, translation);
@@ -142,7 +151,16 @@ class MessagesConfiguratorController extends ConfiguratorController {
 
       case MessagesConfigAction.resetStandardMessageTranslation:
         StandardMessageData messageData = data;
-        var message = standardMessagesManager.standardMessagesInStorage.firstWhere((element) => element.docId == messageData.messageId);
+        var message = standardMessagesManager.standardMessagesInStorage.firstWhere((element) => element.docId == messageData.messageId, orElse: () {
+          return null;
+        });
+        if (message == null) {
+          var localMessage = standardMessagesManager.standardMessagesInLocal.firstWhere((element) => element.docId == messageData.messageId);
+          var textToReset = localMessage.text;
+          var standardMessage = standardMessagesManager.modifyMessage(messageData.messageId, textToReset, "");
+          _modifyMessagesInView([standardMessage]);
+          break;
+        }
         var textToReset = standardMessagesManager.localCategories[message.categoryId].groups[message.groupId].messages[message.docId].text;
         var translation = standardMessagesManager.storageCategories[message.categoryId].groups[message.groupId].messages[message.docId].translation;
         var standardMessage = standardMessagesManager.modifyMessage(messageData.messageId, textToReset, translation);

--- a/webapp/lib/app/configurator/standard_messages/controller_messages_helper.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller_messages_helper.dart
@@ -30,7 +30,8 @@ class StandardMessagesManager {
       var currentIndex = category.categoryIndex ?? 0;
       return maxIndex > currentIndex ? maxIndex : currentIndex;
     });
-    return lastIndex + 1;
+    var length = localCategories.values.length;
+    return lastIndex >= length ? length : lastIndex + 1;
   }
 
   int getNextGroupIndexInCategory(String categoryId) {
@@ -38,7 +39,8 @@ class StandardMessagesManager {
       var currentIndex = group.groupIndexInCategory ?? 0;
       return maxIndex > currentIndex ? maxIndex : currentIndex;
     });
-    return lastIndex + 1;
+    var length = localCategories[categoryId].groups.length;
+    return lastIndex >= length ? length : lastIndex + 1;
   }
 
   int getNextMessageIndexInGroup(String categoryId, String groupId) {
@@ -47,7 +49,8 @@ class StandardMessagesManager {
       var currentIndex = r.indexInGroup ?? 0;
       return maxIndex > currentIndex ? maxIndex : currentIndex;
     });
-    return lastIndexInGroup + 1;
+    var length = localCategories[categoryId].groups[groupId].messages.length;
+    return lastIndexInGroup >= length ? length : lastIndexInGroup + 1;
   }
 
   Map<String, MessageCategory> storageCategories = {};
@@ -92,11 +95,17 @@ class StandardMessagesManager {
         unsavedGroupIds.add(storageMessage.groupId);
         unsavedCategoryIds.add(storageMessage.categoryId);
       } else if (storageMessage == null) { // message added
-        editedMessages.add(localMessage);
-        unsavedMessageTextIds.add(localMessage.suggestedReplyId);
-        unsavedMessageTranslationIds.add(localMessage.suggestedReplyId);
-        unsavedGroupIds.add(localMessage.groupId);
-        unsavedCategoryIds.add(localMessage.categoryId);
+        if (localMessage.text != "" || localMessage.translation != "") {
+          editedMessages.add(localMessage);
+          unsavedGroupIds.add(localMessage.groupId);
+          unsavedCategoryIds.add(localMessage.categoryId);
+        }
+        if (localMessage.text != "") {
+          unsavedMessageTextIds.add(localMessage.suggestedReplyId);
+        }
+        if (localMessage.translation != "") {
+          unsavedMessageTranslationIds.add(localMessage.suggestedReplyId);
+        }
       } else { // message edited
         var isMessageEdited = false;
         if (localMessage.categoryName != storageMessage.categoryName) { // renamed category

--- a/webapp/lib/app/configurator/standard_messages/controller_messages_helper.dart
+++ b/webapp/lib/app/configurator/standard_messages/controller_messages_helper.dart
@@ -95,15 +95,15 @@ class StandardMessagesManager {
         unsavedGroupIds.add(storageMessage.groupId);
         unsavedCategoryIds.add(storageMessage.categoryId);
       } else if (storageMessage == null) { // message added
-        if (localMessage.text != "" || localMessage.translation != "") {
+        if (localMessage.text.isEmpty || localMessage.translation.isEmpty) {
           editedMessages.add(localMessage);
           unsavedGroupIds.add(localMessage.groupId);
           unsavedCategoryIds.add(localMessage.categoryId);
         }
-        if (localMessage.text != "") {
+        if (localMessage.text.isEmpty) {
           unsavedMessageTextIds.add(localMessage.suggestedReplyId);
         }
-        if (localMessage.translation != "") {
+        if (localMessage.translation.isEmpty) {
           unsavedMessageTranslationIds.add(localMessage.suggestedReplyId);
         }
       } else { // message edited

--- a/webapp/pubspec.lock
+++ b/webapp/pubspec.lock
@@ -264,8 +264,8 @@ packages:
     dependency: "direct main"
     description:
       path: ui
-      ref: "52bf4cd064c1645a3c532e6242a98d34799fd206"
-      resolved-ref: "52bf4cd064c1645a3c532e6242a98d34799fd206"
+      ref: a1f6166e272606712b326eb52f17f3b5650e280e
+      resolved-ref: a1f6166e272606712b326eb52f17f3b5650e280e
       url: "git@github.com:larksystems/katikati_common_lib.git"
     source: git
     version: "0.0.1"

--- a/webapp/pubspec.yaml
+++ b/webapp/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     git:
       url: git@github.com:larksystems/katikati_common_lib.git
       path: ui
-      ref: 52bf4cd064c1645a3c532e6242a98d34799fd206
+      ref: a1f6166e272606712b326eb52f17f3b5650e280e
 
 dev_dependencies:
   build_runner: ^1.7.0


### PR DESCRIPTION
+ Do not show reset button as soon as a message is added for the first time
+ Correct for lastIndex of messages, groups, categories that are greater than the parent length
+ Fix the case where the messages in storage might be null hindering comparison i.e. when a new message/group/category is just added

Related https://github.com/larksystems/Katikati-Core/issues/881