### PR TITLE
Rename tooltip class for sample messages and import tooltip.css

### DIFF
--- a/webapp/lib/app/configurator/tags/view.dart
+++ b/webapp/lib/app/configurator/tags/view.dart
@@ -262,7 +262,7 @@ class SampleMessagesTooltip {
 
   SampleMessagesTooltip(String title, this._tagId) {
     tooltip = new DivElement()
-      ..classes.add('tooltip')
+      ..classes.add('sample-msg-tooltip')
       ..onMouseEnter.listen((e) {
         if (onMouseEnter == null) return;
         onMouseEnter();
@@ -272,7 +272,7 @@ class SampleMessagesTooltip {
         onMouseLeave();
       });
 
-    var titleElement = new AnchorElement(href: _linkToFilteredConversationView(tagId: _tagId))..classes.add('tooltip__title');
+    var titleElement = new AnchorElement(href: _linkToFilteredConversationView(tagId: _tagId))..classes.add('sample-msg-tooltip__title');
     titleElement.append(SpanElement()..className = 'fas fa-external-link-square-alt');
     titleElement.append(SpanElement()..innerText = " ${title}");
     tooltip.append(titleElement);
@@ -284,9 +284,9 @@ class SampleMessagesTooltip {
       ..right = '10px';
     removeButton.parent = tooltip;
 
-    _messages = new DivElement()..classes.add('tooltip__messages');
+    _messages = new DivElement()..classes.add('sample-msg-tooltip__messages');
     var loadingText = DivElement()
-      ..classes.add('tooltip__placeholder')
+      ..classes.add('sample-msg-tooltip__placeholder')
       ..innerText = "Loading...";
     _messages..append(loadingText);
 
@@ -298,14 +298,14 @@ class SampleMessagesTooltip {
 
     if (messages.isEmpty) {
       var noMessageText = SpanElement()
-        ..classes.add("tooltip__placeholder")
+        ..classes.add("sample-msg-tooltip__placeholder")
         ..innerText = "No messages with this tag.";
       _messages.append(noMessageText);
       return;
     }
 
     for (var message in messages) {
-      var messageLink = AnchorElement(href: _linkToFilteredConversationView(messageId: message.id, tagId: _tagId))..classes.add('tooltip__message');
+      var messageLink = AnchorElement(href: _linkToFilteredConversationView(messageId: message.id, tagId: _tagId))..classes.add('sample-msg-tooltip__message');
       var linkIcon = SpanElement()..className = 'fas fa-external-link-alt';
       var messageText = SpanElement()..innerText = "  ${message.text}";
       messageLink..append(linkIcon)..append(messageText);

--- a/webapp/web/configure/tags.css
+++ b/webapp/web/configure/tags.css
@@ -22,7 +22,7 @@
   line-height: 1.2;
 }
 
-.tooltip {
+.sample-msg-tooltip {
   position: absolute;
   top: 100%;
   width: 300px;
@@ -37,24 +37,24 @@
   font-style: normal;
 }
 
-.tooltip__title {
+.sample-msg-tooltip__title {
   font-weight: bold;
   color: var(--primary-text-color);
   cursor: pointer;
 }
 
-.tooltip__messages {
+.sample-msg-tooltip__messages {
   display: flex;
   flex-wrap: wrap;
 }
 
-.tooltip__placeholder {
+.sample-msg-tooltip__placeholder {
   color: var(--dark-gray);
   font-style: italic;
   padding: 2px 4px;
 }
 
-.tooltip__message {
+.sample-msg-tooltip__message {
   flex: 1 1 auto;
   margin: 3px;
   padding: 2px 4px;
@@ -65,7 +65,7 @@
   text-decoration: none;
 }
 
-.tooltip__message:hover {
+.sample-msg-tooltip__message:hover {
   background: var(--lighter-background-color);
 }
 

--- a/webapp/web/configure/tags.html
+++ b/webapp/web/configure/tags.html
@@ -21,6 +21,7 @@
   <link rel="stylesheet" href="/packages/katikati_ui_lib/components/accordion/accordion.css">
   <link rel="stylesheet" href="/packages/katikati_ui_lib/components/editable/editable_text.css">
   <link rel="stylesheet" href="/packages/katikati_ui_lib/components/menu/menu.css">
+  <link rel="stylesheet" href="/packages/katikati_ui_lib/components/tooltip/tooltip.css">
   <link rel="stylesheet" href="configuration.css">
   <link rel="stylesheet" href="tags.css">
   <link rel="stylesheet" href="important.css">


### PR DESCRIPTION
I think this slipped through a while back when we added the tooltip to some of the accordion buttons

TBR