### PR TITLE
User permissions page

### DIFF
--- a/webapp/lib/app/users/app.dart
+++ b/webapp/lib/app/users/app.dart
@@ -1,0 +1,3 @@
+import 'controller.dart' as controller;
+
+void init() => new controller.UsersController();

--- a/webapp/lib/app/users/controller.dart
+++ b/webapp/lib/app/users/controller.dart
@@ -1,0 +1,242 @@
+library controller;
+
+import 'dart:html';
+import 'package:katikati_ui_lib/components/logger.dart';
+import 'package:nook/app/nook/controller.dart';
+import 'package:nook/platform/platform.dart';
+import 'package:katikati_ui_lib/components/model/model.dart' as model;
+import 'view.dart';
+import 'dart:async';
+
+Logger log = new Logger('controller.dart');
+
+enum UsersAction {
+  updateBoolPermission,
+  updateStringPermission,
+  updateStringSetPermission,
+  savePermissions,
+  resetToDefaultPermission
+}
+
+class UpdateBoolPermission extends Data {
+  String email;
+  String permissionKey;
+  bool value;
+
+  UpdateBoolPermission(this.email, this.permissionKey, this.value);
+}
+
+class UpdateStringPermission extends Data {
+  String email;
+  String permissionKey;
+  String value;
+
+  UpdateStringPermission(this.email, this.permissionKey, this.value);
+}
+
+class ResetToDefaultPermission extends Data {
+  String email;
+  String permissionKey;
+
+  ResetToDefaultPermission(this.email, this.permissionKey);
+}
+
+UsersController controller;
+UsersPageView get _view => controller.view;
+
+class UsersController extends Controller {
+
+  model.UserConfiguration defaultConfig;
+  Map<String, model.UserConfiguration> userConfigs;
+  Map<String, Map<String, dynamic>> editedConfig;
+
+  UsersController(): super() {}
+
+  @override
+  void init() {
+    view = UsersPageView(this);
+    platform = new Platform(this);
+    controller = this;
+    editedConfig = {};
+  }
+
+  @override
+  void setUpOnLogin() {
+    _listenForUserConfig();
+  }
+
+  void _listenForUserConfig() {
+    platform.listenForUserConfigurations((added, modified, removed) {
+      if (added.isNotEmpty) {
+        List<model.UserConfiguration> addedUserConfig = new List()
+          ..addAll(added);
+
+        defaultConfig = addedUserConfig.singleWhere((c) => c.docId == 'default', orElse: () => null);
+
+        userConfigs = userConfigs ?? {};
+        addedUserConfig.where((c) => c.docId != 'default').forEach((c) {
+          userConfigs[c.docId] = c;
+        });
+
+        _view.populateTable(defaultConfig, userConfigs);
+      }
+
+      if (modified.isNotEmpty) {
+        List<model.UserConfiguration> modifiedUserConfig = new List()
+          ..addAll(modified);
+
+        var newDefaultConfig = modifiedUserConfig.singleWhere((c) => c.docId == 'default', orElse: () => null);
+        if (newDefaultConfig != null) {
+          defaultConfig = newDefaultConfig;
+        }
+
+        userConfigs = userConfigs ?? {};
+        modifiedUserConfig.where((c) => c.docId != 'default').forEach((c) {
+          userConfigs[c.docId] = c.applyDefaults(defaultConfig);
+          var modifiedObj = c.toData();
+          modifiedObj.keys.forEach((permissionKey) {
+
+            if (editedConfig.containsKey(c.docId)) {
+              if (editedConfig[c.docId].containsKey(permissionKey)) {
+                editedConfig[c.docId].remove(permissionKey);
+              }
+              if (editedConfig[c.docId].isEmpty) {
+                editedConfig.remove(c.docId);
+              }
+            }
+            
+            var valueToUpdate = modifiedObj[permissionKey];
+            var valueType = valueToUpdate.runtimeType.toString();
+            if (valueType == 'bool') {
+              _view.updateBoolPermission(c.docId, permissionKey, valueToUpdate);
+            } else if (valueType == 'String') {
+              _view.updateStringPermission(c.docId, permissionKey, valueToUpdate);
+            } else if (valueType == 'List<String>') {
+              _view.updateListStringPermission(c.docId, permissionKey, valueToUpdate);
+            } else {
+              log.error("Unknown data type for ${c.docId}, ${permissionKey}, ${valueToUpdate}");
+            }
+          });
+        });
+      }
+
+      // todo: handle removal of user
+      _view.enableSaveButton(editedConfig.isNotEmpty);
+    });
+  }
+
+  void command(action, [Data data]) {
+    if (action is! UsersAction) {
+      super.command(action, data);
+      return;
+    }
+
+    switch (action) {
+      case UsersAction.savePermissions:
+        _view.setSaveText("Updating…");
+        _view.enableSaveButton(false);
+        platform.updateUserConfiguration(editedConfig).then((_) {
+          editedConfig.keys.forEach((email) {
+            _view.markAsUnsaved(email, true);
+          });
+          editedConfig = {};
+          _view.setSaveText("Updated!");
+          new Timer(new Duration(seconds: 2), () => _view.setSaveText("Update permissions"));
+        });
+        break;
+
+      case UsersAction.updateBoolPermission:
+        var updateData = data as UpdateBoolPermission;
+        if (isDefaultPermission(updateData.email)) {
+          var userDataObj = defaultConfig.toData();
+          userDataObj[updateData.permissionKey] = updateData.value;
+          defaultConfig = model.UserConfiguration.fromData(userDataObj);
+          for (var email in userConfigs.keys) {
+            if (email != 'default') {
+              var valueToUpdate = userConfigs[email].toData()[updateData.permissionKey] ?? updateData.value;
+              _view.updateBoolPermission(email, updateData.permissionKey, valueToUpdate);
+            }
+          }
+        } else {
+          var userDataObj = userConfigs[updateData.email].toData();
+          userDataObj[updateData.permissionKey] = updateData.value;
+          userConfigs[updateData.email] = model.UserConfiguration.fromData(userDataObj);
+        }
+        editedConfig[updateData.email] = editedConfig[updateData.email] ?? {};
+        editedConfig[updateData.email][updateData.permissionKey] = updateData.value;
+        _view.markAsUnsaved(updateData.email, false);
+        _view.enableSaveButton(editedConfig.isNotEmpty);
+        break;
+
+      case UsersAction.updateStringPermission:
+        var updateData = data as UpdateStringPermission;
+        if (isDefaultPermission(updateData.email)) {
+          var userDataObj = defaultConfig.toData();
+          userDataObj[updateData.permissionKey] = updateData.value;
+          defaultConfig = model.UserConfiguration.fromData(userDataObj);
+          for (var email in userConfigs.keys) {
+            if (email != 'default') {
+              var valueToUpdate = userConfigs[email].toData()[updateData.permissionKey] ?? updateData.value;
+              _view.updateStringPermission(email, updateData.permissionKey, valueToUpdate);
+            }
+          }
+        } else {
+          var userDataObj = userConfigs[updateData.email].toData();
+          userDataObj[updateData.permissionKey] = updateData.value;
+          userConfigs[updateData.email] = model.UserConfiguration.fromData(userDataObj);
+        }
+        editedConfig[updateData.email] = editedConfig[updateData.email] ?? {};
+        editedConfig[updateData.email][updateData.permissionKey] = updateData.value;
+        _view.markAsUnsaved(updateData.email, false);
+        _view.enableSaveButton(editedConfig.isNotEmpty);
+        break;
+
+      case UsersAction.updateStringSetPermission:
+        var updateData = data as UpdateStringPermission;
+        var values = updateData.value.split(",").map((e) => e.trim()).toList();
+        if (isDefaultPermission(updateData.email)) {
+          var userDataObj = defaultConfig.toData();
+          userDataObj[updateData.permissionKey] = values;
+          defaultConfig = model.UserConfiguration.fromData(userDataObj);
+          for (var email in userConfigs.keys) {
+            if (email != 'default') {
+              var valueToUpdate = userConfigs[email].toData()[updateData.permissionKey] ?? updateData.value.split(",");
+              _view.updateListStringPermission(email, updateData.permissionKey, valueToUpdate);
+            }
+          }
+        } else {
+          var userDataObj = userConfigs[updateData.email].toData();
+          userDataObj[updateData.permissionKey] = values;
+          userConfigs[updateData.email] = model.UserConfiguration.fromData(userDataObj);
+        }
+        editedConfig[updateData.email] = editedConfig[updateData.email] ?? {};
+        editedConfig[updateData.email][updateData.permissionKey] = values;
+        _view.markAsUnsaved(updateData.email, false);
+        _view.enableSaveButton(editedConfig.isNotEmpty);
+        break;
+      
+      case UsersAction.resetToDefaultPermission:
+        var resetData = data as ResetToDefaultPermission;
+        var userDataObj = userConfigs[resetData.email].toData();
+
+        var valueType = userDataObj[resetData.permissionKey].runtimeType.toString();
+
+        userDataObj[resetData.permissionKey] = null;
+        userConfigs[resetData.email] = model.UserConfiguration.fromData(userDataObj);
+        editedConfig[resetData.email] = editedConfig[resetData.email] ?? {};
+        editedConfig[resetData.email][resetData.permissionKey] = null;
+
+        _view.markAsUnsaved(resetData.email, false);
+        _view.enableSaveButton(editedConfig.isNotEmpty);
+
+        if (valueType == 'bool') {
+          _view.updateBoolPermission(resetData.email, resetData.permissionKey, defaultConfig.toData()[resetData.permissionKey], setToDefault: true);
+        } else if (valueType == 'String') {
+          _view.updateStringPermission(resetData.email, resetData.permissionKey, defaultConfig.toData()[resetData.permissionKey] ?? "", setToDefault: true);
+        } else if (valueType == 'List<String>') {
+          _view.updateListStringPermission(resetData.email, resetData.permissionKey, defaultConfig.toData()[resetData.permissionKey] ?? [], setToDefault: true);
+        }
+        break;
+    }
+  }
+}

--- a/webapp/lib/app/users/view.dart
+++ b/webapp/lib/app/users/view.dart
@@ -1,0 +1,259 @@
+import 'dart:html';
+import 'package:katikati_ui_lib/components/button/button.dart';
+import 'package:katikati_ui_lib/components/logger.dart';
+import 'package:katikati_ui_lib/datatypes/user.dart';
+import 'package:nook/view.dart';
+
+import 'controller.dart';
+
+Logger log = new Logger('view.dart');
+
+class Permission {
+  String key;
+  String type;
+  String explanation = "Explanation shows up here";
+
+  Permission(this.key, this.type);
+}
+
+Map<String, List<Permission>> permissionGroups = {
+  "Sending message": [
+    Permission("send_messages_enabled", "bool"),
+    Permission("send_custom_messages_enabled", "bool"),
+    Permission("send_multi_message_enabled", "bool"),
+  ],
+  "Standard messages": [
+    Permission("sample_messages_enabled", "bool"),
+    Permission("edit_standard_messages_enabled", "bool"),
+  ],
+  "Tags": [
+    Permission("mandatory_include_tag_ids", "Set<String>"),
+    Permission("mandatory_exclude_tag_ids", "Set<String>"),
+    Permission("edit_tags_enabled", "bool"),
+    
+  ],
+  "Conversations UI": [
+    Permission("tag_messages_enabled", "bool"),
+    Permission("tag_conversations_enabled", "bool"),
+    Permission("edit_translations_enabled", "bool"),
+    Permission("edit_notes_enabled", "bool"),
+    Permission("conversational_turns_enabled", "bool"),
+    Permission("tags_panel_visibility", "bool"),
+    Permission("replies_panel_visibility", "bool"),
+    Permission("suggested_replies_groups_enabled", "bool"),
+    Permission("tags_keyboard_shortcuts_enabled", "bool"),
+    Permission("replies_keyboard_shortcuts_enabled", "bool"),
+  ],
+  "Miscellaneous": [
+    Permission("console_logging_level", "String"),
+  ]
+};
+
+const DEFAULT_KEY = "default";
+const VALUE_FROM_DEFAULT_CSS_CLASS = "from-default";
+bool isDefaultPermission(key) => key == DEFAULT_KEY;
+
+class UsersPageView extends PageView {
+  HeadingElement headerElement;
+  ParagraphElement helperElement;
+  DivElement tableWrapper;
+  DivElement footerWrapper;
+  ButtonElement saveButton;
+
+  // email > permission key > header/checkbox/textbox
+  Map<String, Element> permissionEmailHeaders;
+  Map<String, Map<String, CheckboxInputElement>> permissionToggles;
+  Map<String, Map<String, TextInputElement>> permissionTextboxes;
+  Map<String, Map<String, SpanElement>> resetToDefaultPermissionsButtons;
+
+  UsersPageView(UsersController controller) : super(controller) {
+
+    permissionEmailHeaders = {};
+    permissionToggles = {};
+    permissionTextboxes = {};
+    resetToDefaultPermissionsButtons = {};
+
+    headerElement = HeadingElement.h1()
+      ..innerText = "User permissions"
+      ..className = "user-permissions__heading";
+    helperElement = ParagraphElement()..innerText = "Default permissions apply to all user accounts unless overridden individually. Muted controls are derived from the default.";
+    tableWrapper = DivElement()
+      ..className = "user-permissions__table-wrapper";
+    tableWrapper.append(ImageElement(src: '/packages/katikati_ui_lib/components/brand_asset/logos/loading.svg')..className = "load-spinner");
+    footerWrapper = DivElement()
+      ..className = "user-permissions__footer";
+
+    saveButton = ButtonElement()
+      ..className = "user-permissions__save-action"
+      ..innerText = "Update permissions"
+      ..disabled = true
+      ..onClick.listen((event) {
+        appController.command(UsersAction.savePermissions, null);
+      });
+    footerWrapper.append(saveButton);
+  }
+
+  void setSaveText(String text) {
+    saveButton.innerText = text;
+  }
+
+  void enableSaveButton(bool enable) {
+    saveButton.disabled = !enable;
+  }
+
+  void updateBoolPermission(String email, String permissionKey, bool value, {bool setToDefault = false}) {
+    permissionToggles[email][permissionKey].checked = value;
+    if (setToDefault) {
+      resetToDefaultPermissionsButtons[email][permissionKey].remove();
+      permissionToggles[email][permissionKey].classes.add(VALUE_FROM_DEFAULT_CSS_CLASS);
+    }
+  }
+
+  void updateStringPermission(String email, String permissionKey, String value, {bool setToDefault = false}) {
+    permissionTextboxes[email][permissionKey].value = value;
+    if (setToDefault) {
+      resetToDefaultPermissionsButtons[email][permissionKey].remove();
+      permissionTextboxes[email][permissionKey].classes.add(VALUE_FROM_DEFAULT_CSS_CLASS);
+    }
+  }
+
+  void updateListStringPermission(String email, String permissionKey, List<String> values, {bool setToDefault = false}) {
+    permissionTextboxes[email][permissionKey].value = values.join(", ");
+    if (setToDefault) {
+      resetToDefaultPermissionsButtons[email][permissionKey].remove();
+      permissionTextboxes[email][permissionKey].classes.add(VALUE_FROM_DEFAULT_CSS_CLASS);
+    }
+  }
+
+  void markAsUnsaved(String email, bool saved) {
+    permissionEmailHeaders[email].classes.toggle("unsaved", !saved);
+  }
+
+  void populateTable(UserConfiguration defaultConfig, Map<String, UserConfiguration> usersConfig) {
+    tableWrapper.children.clear();
+    var table = TableElement();
+    // thead, tbody
+    var tableHeader = table.createTHead();
+    var tableBody = table.createTBody();
+    table
+      ..append(tableHeader)
+      ..append(tableBody);
+
+    var allEmails = [defaultConfig.docId]..addAll(usersConfig.keys);
+
+    // email headers
+    var headerRow = TableRowElement()..append(Element.th());
+    allEmails.forEach((email) {
+      var emailHeader = Element.th()..innerText = email;
+      permissionEmailHeaders[email] = emailHeader;
+      headerRow.append(emailHeader);
+    });
+    tableHeader.append(headerRow);
+
+    var defaultConfigMap = defaultConfig.toData();
+
+    for (var group in permissionGroups.keys) {
+      var groupTitle = TableRowElement()
+        ..append(Element.td()..className = "group-row"..innerText = group)
+        ..append(Element.td()..className = "group-row--empty"..attributes["colspan"] = allEmails.length.toString());
+      tableBody.append(groupTitle);
+      for (var permission in permissionGroups[group]) {
+        var permissionRow = TableRowElement();
+        var permissionText = DivElement()..innerText = permission.key;
+        var permissionExplanation = SpanElement()..className = "permission-explanation"..innerText = permission.explanation;
+        permissionRow.append(Element.th()..append(permissionText)..append(permissionExplanation));
+
+        allEmails.forEach((email) {
+          var permissionMap = isDefaultPermission(email) ? defaultConfigMap : usersConfig[email].toData();
+          var permissionValue = permissionMap[permission.key];
+          SpanElement resetToDefault;
+          bool derivedFromDefault = !isDefaultPermission(email) && permissionValue == null;
+          if (derivedFromDefault) {
+            permissionValue = defaultConfigMap[permission.key];
+          } else {
+            if (!isDefaultPermission(email)) {
+              var resetButton = Button(ButtonType.reset, hoverText: 'Reset to default', onClick: (_) {
+                appController.command(UsersAction.resetToDefaultPermission, ResetToDefaultPermission(email, permission.key));
+              });
+              resetToDefault = resetButton.renderElement;
+              resetToDefaultPermissionsButtons[email] = resetToDefaultPermissionsButtons[email] ?? {};
+              resetToDefaultPermissionsButtons[email][permission.key] = resetToDefault;
+            }
+          }
+
+          Element renderElement;
+          switch (permission.type) {
+            case 'bool':
+              renderElement = CheckboxInputElement()
+                ..checked = permissionValue
+                ..onChange.listen((event) {
+                  renderElement.classes.remove(VALUE_FROM_DEFAULT_CSS_CLASS);
+                  appController.command(UsersAction.updateBoolPermission, UpdateBoolPermission(email, permission.key, (event.target as CheckboxInputElement).checked));
+                });
+              if (derivedFromDefault) {
+                renderElement.classes.add(VALUE_FROM_DEFAULT_CSS_CLASS);
+              }
+              permissionToggles[email] = permissionToggles[email] ?? {};
+              permissionToggles[email][permission.key] = renderElement;
+              break;
+            case 'String':
+              renderElement = TextInputElement()
+                ..value = permissionValue
+                ..onInput.listen((event) {
+                  renderElement.classes.remove(VALUE_FROM_DEFAULT_CSS_CLASS);
+                  appController.command(UsersAction.updateStringPermission, UpdateStringPermission(email, permission.key, (event.target as TextInputElement).value));
+                });
+              if (derivedFromDefault) {
+                renderElement.classes.add(VALUE_FROM_DEFAULT_CSS_CLASS);
+              }
+              permissionTextboxes[email] = permissionTextboxes[email] ?? {};
+              permissionTextboxes[email][permission.key] = renderElement;
+              break;
+            case 'Set<String>':
+              renderElement = TextInputElement()
+                ..value = (permissionValue as List<String>).join(",")
+                ..onInput.listen((event) {
+                  renderElement.classes.remove(VALUE_FROM_DEFAULT_CSS_CLASS);
+                  appController.command(UsersAction.updateStringSetPermission, UpdateStringPermission(email, permission.key, (event.target as TextInputElement).value));
+                });
+              if (derivedFromDefault) {
+                renderElement.classes.add(VALUE_FROM_DEFAULT_CSS_CLASS);
+              }
+              permissionTextboxes[email] = permissionTextboxes[email] ?? {};
+              permissionTextboxes[email][permission.key] = renderElement;
+              break;
+            default:
+              renderElement = SpanElement()..innerText = "Unknown data type";
+              break;
+          }
+          var cell = TableCellElement()
+            ..append(renderElement)
+            ..onMouseEnter.listen((event) {
+              permissionEmailHeaders[email].classes.toggle('highlight', true);
+            })
+            ..onMouseLeave.listen((event) {
+              permissionEmailHeaders[email].classes.toggle('highlight', false);
+            });
+          if (resetToDefault != null) {
+            cell.append(resetToDefault);
+          }
+          permissionRow.append(cell);
+        });
+        tableBody.append(permissionRow);
+      }
+    }
+      
+    tableWrapper.children.clear();
+    tableWrapper.append(table);
+  }
+
+  @override
+  initSignedInView(String displayName, String photoUrl) {
+    super.initSignedInView(displayName, photoUrl);
+    mainElement
+      ..append(headerElement)
+      ..append(helperElement)
+      ..append(tableWrapper)
+      ..append(footerWrapper);
+  }
+}

--- a/webapp/lib/platform/platform.dart
+++ b/webapp/lib/platform/platform.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import 'dart:html';
 
 import 'package:firebase/firebase.dart' as firebase;
 
@@ -257,6 +258,14 @@ class Platform {
 
   void listenForUserPresence(UserPresenceCollectionListener listener, [OnErrorListener onErrorListener]) {
     _userPresenceSubscription = UserPresence.listen(_docStorage, listener, onErrorListener: onErrorListener);
+  }
+
+  Future<void> updateUserConfiguration(Map<String, Map<String, dynamic>> updates) {
+    List<Future> futures = [];
+    for (var email in updates.keys) {
+      futures.add(platform.firestoreInstance.collection("users").doc(email).update(data: updates[email]));
+    }
+    return Future.wait(futures);
   }
 
   Future<void> addMessageTag(Conversation conversation, Message message, String tagId) {

--- a/webapp/web/users/index.html
+++ b/webapp/web/users/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+  <title>Users</title>
+
+  <script defer src="main.dart.js"></script>
+  
+  <link rel="icon" href="/packages/katikati_ui_lib/components/brand_asset/logos/favicon.ico" />
+  <link rel="stylesheet" type="text/css" href="/packages/katikati_ui_lib/global.css">
+  <link rel="stylesheet" type="text/css" href="/packages/katikati_ui_lib/fontawesome/css/all.min.css" >
+  <link rel="stylesheet" type="text/css" href="/packages/katikati_ui_lib/components/load_spinner/load_spinner.css">
+  <link rel="stylesheet" type="text/css" href="/packages/katikati_ui_lib/components/auth/auth.css">
+  <link rel="stylesheet" type="text/css" href="/packages/katikati_ui_lib/components/nav/nav.css">
+  <link rel="stylesheet" type='text/css' href="/packages/katikati_ui_lib/components/nav/button_links.css">
+  <link rel="stylesheet" type="text/css" href="/packages/katikati_ui_lib/components/tooltip/tooltip.css">
+  <link rel="stylesheet" type="text/css" href="/packages/katikati_ui_lib/components/tag/tag.css">
+  <link rel="stylesheet" type="text/css" href="/packages/katikati_ui_lib/components/button/button.css">
+  <link rel="stylesheet" type="text/css" href="/packages/katikati_ui_lib/components/load_spinner/load_spinner.css">
+  <link rel="stylesheet" type="text/css" href="users.css">
+
+  <script src="https://www.gstatic.com/firebasejs/7.2.0/firebase-app.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/7.2.0/firebase-firestore.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/7.2.0/firebase-auth.js"></script>
+</head>
+
+<body>
+  <header></header>
+  <main></main>
+  <footer></footer>
+</body>
+
+</html>

--- a/webapp/web/users/main.dart
+++ b/webapp/web/users/main.dart
@@ -1,0 +1,5 @@
+import 'package:nook/app/users/app.dart' as app;
+
+void main() {
+  app.init();
+}

--- a/webapp/web/users/users.css
+++ b/webapp/web/users/users.css
@@ -1,0 +1,137 @@
+body {
+    font-size: 14px; 
+    line-height: 1.5;
+}
+
+.user-permissions__heading {
+    font-size: var(--h1-font-size);
+    margin-top: var(--spacer);
+}
+
+.user-permissions__footer {
+    background-color: white;
+    position: fixed;
+    border-top: 1px solid var(--light-gray);
+    padding: var(--spacer-small);
+    width: 100%;
+    bottom: 0;
+    z-index: 5;
+}
+
+.user-permissions__save-action {
+    padding: 10px 15px;
+    background-color: var(--orange);
+    color: var(--black);
+    border: none;
+    cursor: pointer;
+}
+
+.user-permissions__save-action:hover {
+    filter: brightness(var(--hover-brightness));
+}
+
+.user-permissions__save-action:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+}
+
+.user-permissions__table-wrapper {
+    overflow-x: scroll;
+    max-width: 100%;
+    max-height: calc(100vh - 120px);
+    overflow-y: auto;
+}
+
+.user-permissions__table-wrapper table {
+    border: none;
+    border-collapse: separate;
+    border-spacing: 0;
+    text-align: left;
+    border-bottom: 1px solid var(--default-border-color);
+    margin-bottom: var(--spacer-6);
+}
+
+.user-permissions__table-wrapper table thead th {
+    background-color: var(--lighter-background-color);
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    border-bottom: 2px solid var(--default-border-color);
+}
+
+
+.user-permissions__table-wrapper table thead th:nth-child(1) {
+    position: sticky;
+    z-index: 4;
+    left: 0;
+    border-right: 2px solid var(--default-border-color);
+}
+
+.user-permissions__table-wrapper table tbody th {
+    position: sticky;
+    left: 0;
+    background-color: white;
+    z-index: 2;
+    border-right: 2px solid var(--default-border-color);
+    padding-left: var(--spacer-2);
+}
+
+.user-permissions__table-wrapper td,
+.user-permissions__table-wrapper th {
+    padding: 6px 12px;
+    border-top: 1px solid var(--default-border-color);
+    border-left: 1px solid var(--default-border-color);
+    min-width: 120px;
+    position: relative;
+}
+
+.user-permissions__table-wrapper td.group-row {
+    position: sticky !important;
+    left: 0;
+    z-index: 2;
+    background: var(--lighter-background-color);
+    font-weight: 600;
+    border-top: 1px solid var(--default-border-color);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-right: 2px solid var(--default-border-color);
+}
+
+.user-permissions__table-wrapper td.group-row--empty {
+    background: var(--lighter-background-color);   
+}
+
+.user-permissions__table-wrapper td:hover .button-wrapper {
+    visibility: visible;
+}
+
+.user-permissions__table-wrapper td .button-wrapper {
+    visibility: hidden;
+    position: absolute;
+    top: 6px;
+    right: 12px;
+}
+
+.user-permissions__table-wrapper tbody tr:hover th, 
+.user-permissions__table-wrapper tr th.highlight {
+    background-color: var(--darkest-gray) !important;
+    color: white !important;
+}
+
+.user-permissions__table-wrapper tbody tr:hover {
+    background-color: var(--default-background-color);
+}
+
+.unsaved {
+    font-style: italic;
+}
+
+.permission-explanation {
+    color: var(--dark-gray);
+    font-size: 12px;
+}
+
+.from-default {
+    opacity: 0.3;
+}


### PR DESCRIPTION
Access via /users/index.html

+ User permissions are displayed in a table (toggles are checkboxes, text & tags are text boxes)
+ Reads from, saves directly to fire store
+ Handles display of values derived from default, along with reset to default
+ Unsaved indicator in the email header

+ Sticky headers, first column. Hover indicators for easier comprehension. Visual grouping for permissions

Limitations
1. Tags input is not smart, for not requires list of comma separated tag ids
2. Conflicts are not handled
3. Toggle all on/off is not available
4. Removed email does not reflect