### PR TITLE
Config tag refactor to include local & storage

### DIFF
--- a/webapp/lib/app/configurator/tags/controller.dart
+++ b/webapp/lib/app/configurator/tags/controller.dart
@@ -158,9 +158,7 @@ class TagsConfiguratorController extends ConfiguratorController {
 
         var tag = tagManager.moveTagAcrossLocalGroups(tagData.id, tagData.groupId, tagData.newGroupId);
         _removeTagsFromView({ tagData.groupId: [tag] });
-        _addTagsToView({ tagData.newGroupId: [tag] }, tagManager.localGroupsById);
-        
-        tagManager.editedTagIds.add(tagData.id);
+        _addTagsToView({ tagData.newGroupId: [tag] }, tagManager.localGroupsById);        
         _updateUnsavedIndicators(tagManager.localTagsByGroupId, tagManager.editedTagIds, tagManager.editedGroupIds);
         break;
 
@@ -182,8 +180,7 @@ class TagsConfiguratorController extends ConfiguratorController {
           return;
         }
 
-        var groupName = "new group";
-        var group = tagManager.createGroupInLocal(groupName);
+        var group = tagManager.createGroupInLocal("new group");
         _addTagsToView({group.groupId: []}, tagManager.localGroupsById, startEditingName: true);
         _updateUnsavedIndicators(tagManager.localTagsByGroupId, tagManager.editedTagIds, tagManager.editedGroupIds);
         break;
@@ -265,14 +262,14 @@ class TagsConfiguratorController extends ConfiguratorController {
         tagManager.removeAllDeletedTags();
         tagManager.removeAllEditedGroups();
 
-        // todo: eb: function
+        // todo: eb: convert this to a helper function to copy over storage to local
         tagManager.localTagsById = {};
         tagManager.storageTagsById.keys.forEach((tagId) {
           tagManager.localTagsById[tagId] = tagManager.storageTagsById[tagId]; // todo: eb: clone!
         });
         _view.showSaveStatus('Modifying tags has been disabled, dropping all changes');
         _view.unsavedChanges = false;
-        // todo: eb: fix existing bug / reset view!
+        // todo: eb: fix existing bug / reset view to discard all user made changes!
         _updateUnsavedIndicators(tagManager.localTagsByGroupId, tagManager.editedTagIds, tagManager.editedGroupIds);
       }
 

--- a/webapp/lib/app/configurator/tags/controller.dart
+++ b/webapp/lib/app/configurator/tags/controller.dart
@@ -11,6 +11,7 @@ import 'package:katikati_ui_lib/components/menu/menu.dart';
 import 'package:nook/app/nook/controller.dart';
 import 'package:nook/platform/platform.dart';
 import 'view.dart';
+import 'dart:math';
 
 part 'controller_view_helper.dart';
 part 'controller_tag_helper.dart';
@@ -54,16 +55,16 @@ class TagData extends Data {
 
 class TagGroupData extends Data {
   // Used when renaming or removing a tag group
-  String groupName;
+  String id;
 
   // Used when renaming a tag group
   String newGroupName;
 
-  TagGroupData(this.groupName, {this.newGroupName});
+  TagGroupData(this.id, {this.newGroupName});
 
   @override
   String toString() {
-    return 'TagData($groupName, {$newGroupName})';
+    return 'TagData($id, {$newGroupName})';
   }
 }
 
@@ -106,10 +107,8 @@ class TagsConfiguratorController extends ConfiguratorController {
           return;
         }
 
-        var tag = tagManager.createTag(tagData.groupId);
-        _addTagsToView({
-          tagData.groupId: [tag]
-        }, startEditing: true);
+        var tag = tagManager.createTagInLocal(tagData.groupId);
+        _addTagsToView({tagData.groupId: [tag]}, tagManager.localTagGroupsById, startEditing: true);
         break;
 
       case TagsConfigAction.requestRenameTag:
@@ -117,12 +116,13 @@ class TagsConfiguratorController extends ConfiguratorController {
         if (!currentConfig.editTagsEnabled) {
           command(BaseAction.showSnackbar, SnackbarData('Renaming a tag is disabled', SnackbarNotificationType.warning));
           // Reshow the tag as the view edits it anyway
-          _modifyTagsInView(Map.fromEntries(tagManager.getTagById(tagData.id).groups.map((g) => new MapEntry(g, [tagManager.getTagById(tagData.id)]))));
+          var renamedTag = tagManager.localTagsById[tagData.id];
+          _modifyTagsInView(Map.fromEntries(renamedTag.groupIds.map((g) => new MapEntry(g, [renamedTag]))), tagManager.localTagGroupsById); // todo: eb: confirm this works!
           return;
         }
 
         var tagText = tagData.text.toLowerCase().trim();
-        var presentTagTexts = tagManager._tags.map((tag) => tag.text.toLowerCase().trim()).toList();
+        var presentTagTexts = tagManager.tagsInLocal.map((tag) => tag.text.toLowerCase().trim()).toList();
 
         if (presentTagTexts.contains(tagText)) {
           _showDuplicateTagWarningModal(tagData.groupId, tagData.id, tagData.text);
@@ -136,13 +136,14 @@ class TagsConfiguratorController extends ConfiguratorController {
         if (!currentConfig.editTagsEnabled) {
           command(BaseAction.showSnackbar, SnackbarData('Renaming a tag is disabled', SnackbarNotificationType.warning));
           // Reshow the tag as the view edits it anyway
-          _modifyTagsInView(Map.fromEntries(tagManager.getTagById(tagData.id).groups.map((g) => new MapEntry(g, [tagManager.getTagById(tagData.id)]))));
+          var renamedTag = tagManager.localTagsById[tagData.id];
+          _modifyTagsInView(Map.fromEntries(renamedTag.groupIds.map((g) => new MapEntry(g, [renamedTag]))), tagManager.localTagGroupsById); // todo: eb: confirm this works!
           return;
         }
 
-        var tag = tagManager.modifyTag(tagData.id, text: tagData.text);
-        _modifyTagsInView(Map.fromEntries(tag.groups.map((g) => new MapEntry(g, [tag]))));
-        _updateUnsavedIndicators(tagManager.tagsByGroup, tagManager.unsavedTagIds, tagManager.unsavedGroupIds);
+        var tag = tagManager.updateTextInLocal(tagData.id, tagData.text);
+        _modifyTagsInView(Map.fromEntries(tag.groupIds.map((g) => new MapEntry(g, [tag]))), tagManager.localTagGroupsById);
+        _updateUnsavedIndicators(tagManager.localTagsByCategoryId, tagManager.editedTagIds, tagManager.editedGroupIds);
         break;
 
       case TagsConfigAction.moveTag:
@@ -150,20 +151,18 @@ class TagsConfiguratorController extends ConfiguratorController {
         if (!currentConfig.editTagsEnabled) {
           command(BaseAction.showSnackbar, SnackbarData('Moving a tag is disabled', SnackbarNotificationType.warning));
           // Reshow the tag as the view edits it anyway
-          _modifyTagsInView(Map.fromEntries(tagManager.getTagById(tagData.id).groups.map((g) => new MapEntry(g, [tagManager.getTagById(tagData.id)]))));
+          var movedTag = tagManager.localTagsById[tagData.id];
+          _modifyTagsInView(Map.fromEntries(movedTag.groupIds.map((g) => new MapEntry(g, [movedTag]))), tagManager.localTagGroupsById); // todo: eb: confirm this works!
           return;
         }
 
-        model.Tag tag = tagManager.modifyTag(tagData.id, group: tagData.newGroupId);
-        // update the view by removing the tag and then adding it
-        _removeTagsFromView({
-          tagData.groupId: [tag]
-        });
-        _addTagsToView({
-          tagData.newGroupId: [tag]
-        });
-        tagManager.movedFromGroupIds.add(tagData.groupId);
-        _updateUnsavedIndicators(tagManager.tagsByGroup, tagManager.unsavedTagIds, tagManager.unsavedGroupIds);
+        var tag = tagManager.removeTagFromLocalGroup(tagData.id, tagData.groupId, skipUpdate: true);
+        tagManager.addTagToLocalGroup(tag, tagData.newGroupId);
+        _removeTagsFromView({ tagData.groupId: [tag] });
+        _addTagsToView({ tagData.newGroupId: [tag] }, tagManager.localTagGroupsById);
+        
+        tagManager.editedTagIds.add(tagData.id);
+        _updateUnsavedIndicators(tagManager.localTagsByCategoryId, tagManager.editedTagIds, tagManager.editedGroupIds);
         break;
 
       case TagsConfigAction.removeTag:
@@ -173,11 +172,9 @@ class TagsConfiguratorController extends ConfiguratorController {
           return;
         }
 
-        model.Tag tag = tagManager.deleteTag(tagData.id);
-        _removeTagsFromView({
-          tagData.groupId: [tag]
-        });
-        _updateUnsavedIndicators(tagManager.tagsByGroup, tagManager.unsavedTagIds, tagManager.unsavedGroupIds);
+        var tag = tagManager.removeTagInLocal(tagData.id);
+        _removeTagsFromView({tagData.groupId: [tag]});
+        _updateUnsavedIndicators(tagManager.localTagsByCategoryId, tagManager.editedTagIds, tagManager.editedGroupIds);
         break;
 
       case TagsConfigAction.addTagGroup:
@@ -186,9 +183,10 @@ class TagsConfiguratorController extends ConfiguratorController {
           return;
         }
 
-        var newGroupName = tagManager.createTagGroup();
-        _addTagsToView({newGroupName: []}, startEditingName: true);
-        _updateUnsavedIndicators(tagManager.tagsByGroup, tagManager.unsavedTagIds, tagManager.unsavedGroupIds);
+        var groupName = "new group";
+        var group = tagManager.createGroupInLocal(groupName);
+        _addTagsToView({group.groupId: []}, tagManager.localTagGroupsById, startEditingName: true);
+        _updateUnsavedIndicators(tagManager.localTagsByCategoryId, tagManager.editedTagIds, tagManager.editedGroupIds);
         break;
 
       case TagsConfigAction.updateTagGroup:
@@ -199,11 +197,8 @@ class TagsConfiguratorController extends ConfiguratorController {
           return;
         }
 
-        tagManager.renameTagGroup(groupData.groupName, groupData.newGroupName);
-        var groupView = _view.groups.queryItem(groupData.groupName);
-        groupView.id = groupData.newGroupName;
-        _view.groups.updateItem(groupData.newGroupName, groupView);
-        _updateUnsavedIndicators(tagManager.tagsByGroup, tagManager.unsavedTagIds, tagManager.unsavedGroupIds);
+        tagManager.renameGroupInLocal(groupData.id, groupData.newGroupName);
+        _updateUnsavedIndicators(tagManager.localTagsByCategoryId, tagManager.editedTagIds, tagManager.editedGroupIds);
         break;
 
       case TagsConfigAction.removeTagGroup:
@@ -213,8 +208,8 @@ class TagsConfiguratorController extends ConfiguratorController {
         }
 
         TagGroupData groupData = data;
-        tagManager.deleteTagGroup(groupData.groupName);
-        _view.removeTagGroup(groupData.groupName);
+        tagManager.removeAllTagsFromGroupInLocal(groupData.id);
+        _view.removeTagGroup(groupData.id);
         break;
 
       case TagsConfigAction.updateTagType:
@@ -224,9 +219,9 @@ class TagsConfiguratorController extends ConfiguratorController {
         }
 
         TagData tagData = data;
-        var tag = tagManager.modifyTag(tagData.id, type: tagData.newType);
-        _modifyTagsInView(Map.fromEntries(tag.groups.map((g) => new MapEntry(g, [tag]))));
-        _updateUnsavedIndicators(tagManager.tagsByGroup, tagManager.unsavedTagIds, tagManager.unsavedGroupIds);
+        var tag = tagManager.updateTypeInLocal(tagData.id, tagData.newType);
+        _modifyTagsInView(Map.fromEntries(tag.groupIds.map((g) => new MapEntry(g, [tag]))), tagManager.localTagGroupsById);
+        _updateUnsavedIndicators(tagManager.localTagsByCategoryId, tagManager.editedTagIds, tagManager.editedGroupIds);
         break;
 
       default:
@@ -238,12 +233,12 @@ class TagsConfiguratorController extends ConfiguratorController {
   @override
   void setUpOnLogin() {
     platform.listenForTags((added, modified, removed) {
-      var tagsAdded = tagManager.addTags(added);
-      var tagsModified = tagManager.updateTags(modified);
-      var tagsRemoved = tagManager.removeTags(removed);
+      var tagsAdded = tagManager.populateTagsInStorage(added);
+      var tagsModified = tagManager.populateTagsInStorage(modified);
+      var tagsRemoved = tagManager.removeTagsFromStorage(removed.map((tag) => tag.tagId).toList());
 
-      _addTagsToView(_groupTagsIntoCategories(tagsAdded));
-      _modifyTagsInView(_groupTagsIntoCategories(tagsModified));
+      _addTagsToView(_groupTagsIntoCategories(tagsAdded), tagManager.storageTagGroupsById);
+      _modifyTagsInView(_groupTagsIntoCategories(tagsModified), tagManager.storageTagGroupsById);
       _removeTagsFromView(_groupTagsIntoCategories(tagsRemoved));
     });
 
@@ -266,12 +261,17 @@ class TagsConfiguratorController extends ConfiguratorController {
 
       // Apply new config
       if (!currentConfig.editTagsEnabled) {
-        tagManager.editedTags.clear();
-        tagManager.movedFromGroupIds.clear();
-        tagManager.deletedTags.clear();
+        tagManager.editedTagIds.clear();
+        tagManager.deletedTagIds.clear();
+        tagManager.editedGroupIds.clear();
+        tagManager.localTagsById = {};
+        tagManager.storageTagsById.keys.forEach((tagId) {
+          tagManager.localTagsById[tagId] = tagManager.storageTagsById[tagId]; // todo: eb: clone!
+        });
         _view.showSaveStatus('Modifying tags has been disabled, dropping all changes');
         _view.unsavedChanges = false;
-        _updateUnsavedIndicators(tagManager.tagsByGroup, tagManager.unsavedTagIds, tagManager.unsavedGroupIds);
+        // todo: eb: fix existing bug / reset view!
+        _updateUnsavedIndicators(tagManager.localTagsByCategoryId, tagManager.editedTagIds, tagManager.editedGroupIds);
       }
 
       if (currentConfig.consoleLoggingLevel.toLowerCase().contains('verbose')) {
@@ -297,31 +297,31 @@ class TagsConfiguratorController extends ConfiguratorController {
 
     // ignore: placeholder for tool/adhoc/tag-data-index-id-script.txt
 
-    platform.updateTags(tagManager.editedTags.values.toList()).then((value) {
-      tagManager.editedTags.clear();
-      tagManager.movedFromGroupIds.clear();
-      if (otherPartSaved) {
-        _view.showSaveStatus('Saved!');
-        _view.unsavedChanges = false;
-        _updateUnsavedIndicators(tagManager.tagsByGroup, tagManager.unsavedTagIds, tagManager.unsavedGroupIds);
-        return;
-      }
-      otherPartSaved = true;
-    }, onError: (error, stacktrace) {
-      _view.showSaveStatus('Unable to save. Please check your connection and try again. If the issue persists, please contact your project administrator');
-    });
+    // platform.updateTags(tagManager.editedTags.values.toList()).then((value) {
+    //   tagManager.editedTags.clear();
+    //   tagManager.movedFromGroupIds.clear();
+    //   if (otherPartSaved) {
+    //     _view.showSaveStatus('Saved!');
+    //     _view.unsavedChanges = false;
+    //     _updateUnsavedIndicators(tagManager.tagsByGroup, tagManager.unsavedTagIds, tagManager.unsavedGroupIds);
+    //     return;
+    //   }
+    //   otherPartSaved = true;
+    // }, onError: (error, stacktrace) {
+    //   _view.showSaveStatus('Unable to save. Please check your connection and try again. If the issue persists, please contact your project administrator');
+    // });
 
-    platform.deleteTags(tagManager.deletedTags.values.toList()).then((value) {
-      tagManager.deletedTags.clear();
-      if (otherPartSaved) {
-        _view.showSaveStatus('Saved!');
-        _view.unsavedChanges = false;
-        _updateUnsavedIndicators(tagManager.tagsByGroup, tagManager.unsavedTagIds, tagManager.unsavedGroupIds);
-        return;
-      }
-      otherPartSaved = true;
-    }, onError: (error, stacktrace) {
-      _view.showSaveStatus('Unable to save. Please check your connection and try again. If the issue persists, please contact your project administrator');
-    });
+    // platform.deleteTags(tagManager.deletedTags.values.toList()).then((value) {
+    //   tagManager.deletedTags.clear();
+    //   if (otherPartSaved) {
+    //     _view.showSaveStatus('Saved!');
+    //     _view.unsavedChanges = false;
+    //     _updateUnsavedIndicators(tagManager.tagsByGroup, tagManager.unsavedTagIds, tagManager.unsavedGroupIds);
+    //     return;
+    //   }
+    //   otherPartSaved = true;
+    // }, onError: (error, stacktrace) {
+    //   _view.showSaveStatus('Unable to save. Please check your connection and try again. If the issue persists, please contact your project administrator');
+    // });
   }
 }

--- a/webapp/lib/app/configurator/tags/controller_tag_helper.dart
+++ b/webapp/lib/app/configurator/tags/controller_tag_helper.dart
@@ -1,219 +1,242 @@
 part of controller;
 
+class TagGroup {
+  String groupId;
+  String groupName;
+  int groupIndex;
+  
+  TagGroup(this.groupId, this.groupName, this.groupIndex);
+}
+
 class TagManager {
   static final TagManager _singleton = TagManager._internal();
-
   TagManager._internal();
-
   factory TagManager() => _singleton;
 
-  /// Returns the set of tags being managed.
-  Set<model.Tag> get tags => Set.from(_tags);
-  Set<model.Tag> _tags = {};
+  Map<String, TagGroup> localTagGroupsById = {};
+  Map<String, TagGroup> storageTagGroupsById = {};
 
-  /// Returns the set of tags being managed, organised by group.
-  Map<String, List<model.Tag>> get tagsByGroup => _tagsByGroup;
-  Map<String, List<model.Tag>> _tagsByGroup = {};
+  Map<String, model.Tag> localTagsById = {};
+  Map<String, model.Tag> storageTagsById = {};
 
-  /// Returns an automatically generated name for a new tag group.
-  /// The name is based on an internal sequence, and verified against existing tag group names.
-  /// If the next group in the sequence already exists, it will recursively try to generate a new one.
-  String get nextTagGroupName {
-    var newTagGroupNameProposal = 'new tag group $nextGroupSeqNo';
-    if (tagsByGroup.containsKey(newTagGroupNameProposal)) {
-      return nextTagGroupName;
-    }
-    return newTagGroupNameProposal;
-  }
+  Set<String> editedTagIds = {};
+  Set<String> deletedTagIds = {};
 
-  /// Returns a new number in the group numbering sequence. Starts the sequence at 1.
-  int get nextGroupSeqNo => ++_lastGroupSeqNo;
-  int _lastGroupSeqNo = 0;
+  Set<String> editedGroupIds = {};
 
-  /// Returns the [Tag] with the given [id].
-  model.Tag getTagById(String id) => _tags.singleWhere((t) => t.tagId == id);
+  List<model.Tag> get tagsInLocal => localTagsById.values.toList();
+  List<model.Tag> get tagsInStorage => storageTagsById.values.toList();
 
-  /// Adds the given [tag] to the list of tags being managed.
-  /// Returns either the [tag] if it's a new tag, or [null] if it already exists and it's an update operation.
-  model.Tag addTag(model.Tag tag) {
-    var added = addTags([tag]);
-    if (added.isNotEmpty) return added.first;
-    return null;
-  }
-
-  /// Adds the given list of [tags] to the list of tags being managed.
-  /// Returns a list confirming which tags have been added as new tags. This allows the caller to account for
-  /// tags being added multiple times, e.g. created via the UI and then saved and confirmed by the platform.
-  List<model.Tag> addTags(List<model.Tag> tags) {
-    List<model.Tag> added = [];
-    for (var tag in tags) {
-      if (_tags.any((t) => t.tagId == tag.tagId)) {
-        _tags.removeWhere((t) => t.tagId == tag.tagId);
-        _tags.add(tag);
-      } else {
-        _tags.add(tag);
-        added.add(tag);
+  Map<String, List<model.Tag>> get localTagsByCategoryId {
+    Map<String, List<model.Tag>> result = {};
+    tagsInLocal.forEach((tag) {
+      for (var categoryId in tag.groupIds) {
+        result[categoryId] = result[categoryId] ?? [];
+        result[categoryId].add(tag);
       }
-
-      if (tag.groups.isEmpty) {
-        _tagsByGroup.putIfAbsent('', () => []).add(tag);
-        continue;
+    });
+    return result;
+  }
+  Map<String, List<model.Tag>> get storageTagsByCategoryId {
+    Map<String, List<model.Tag>> result = {};
+    tagsInStorage.forEach((tag) {
+      for (var categoryId in tag.groupIds) {
+        result[categoryId] = result[categoryId] ?? [];
+        result[categoryId].add(tag);
       }
-      for (var group in tag.groups) {
-        _tagsByGroup.putIfAbsent(group, () => []).add(tag);
-      }
-    }
-    return added;
+    });
+    return result;
   }
 
-  /// Updates the given [tag] in the list of tags being managed.
-  /// Returns either the [tag] if it has been updated successfully,
-  /// or [null] if the tag doesn't exist in the list of managed tags and so nothing has been updated.
-  model.Tag updateTag(model.Tag tag) {
-    var updated = updateTags([tag]);
-    if (updated.isNotEmpty) return updated.first;
-    return null;
+  bool get hasUnsavedTags => editedTagIds.isNotEmpty || deletedTagIds.isNotEmpty || editedGroupIds.isNotEmpty;
+
+  int _getNextGroupIndex() {
+    var lastIndex = localTagGroupsById.values
+      .map((tagGroup) => tagGroup.groupIndex)
+      .reduce(max);
+    return lastIndex + 1;
   }
 
-  /// Updates the given list of [tags] to the list of tags being managed.
-  /// Returns a list confirming which tags have been updated sucessfully.
-  /// Tags which don't yet exist in the list of managed tags won't be added to the returned list.
-  List<model.Tag> updateTags(List<model.Tag> tags) {
-    var removed = removeTags(tags);
-    var updated = addTags(removed);
-    if (removed.length != updated.length) {
-      throw "Tag consistency error: The two-step update process has an inconsistency between the tags to be updated";
-    }
-    return updated;
+  void markAsEditedTag(String id) {
+    editedTagIds.add(id);
   }
 
-  /// Removes the given [tag] from the list of tags being managed.
-  /// Returns either the [tag] if it's been removed successfully, or [null] if the tag has already been removed.
-  model.Tag removeTag(model.Tag tag) {
-    var removed = removeTags([tag]);
-    if (removed.isNotEmpty) return removed.first;
-    return null;
+  void markAsDeletedTag(String id) {
+    deletedTagIds.add(id);
   }
 
-  /// Removes the given list of [tags] from the list of tags being managed.
-  /// Returns a list confirming which tags have been removed successfully. This allows the caller to account for
-  /// tags being removed multiple times, e.g. removed via the UI and then saved and confirmed by the platform.
-  List<model.Tag> removeTags(List<model.Tag> tags) {
-    List<model.Tag> removed = [];
-    for (var tag in tags) {
-      if (!_tags.any((t) => t.tagId == tag.tagId)) {
-        log.warning("Tag consistency error: Removing tag that doesn't exist, ${tag.tagId}");
-        continue;
-      }
-
-      var oldTag = _tags.singleWhere((t) => t.tagId == tag.tagId, orElse: () => null);
-      _tags.remove(oldTag);
-      removed.add(tag);
-
-      if (oldTag.groups.isEmpty) {
-        _tagsByGroup[''].remove(oldTag);
-        continue;
-      }
-      for (var group in oldTag.groups) {
-        _tagsByGroup[group].remove(oldTag);
-      }
-    }
-    return removed;
-  }
-
-  /// Creates and returns a new tag in the given tag [group].
-  /// Also adds the tag to the list of tags that have been edited and need to be saved.
-  model.Tag createTag(String group) {
-    var tag = new model.Tag()
+  model.Tag createTagInLocal(String groupId) {
+    var tag = model.Tag()
       ..docId = model.generateTagId()
       ..filterable = true
-      ..groups = [group]
+      ..groupIds = [groupId]
+      ..groupIndices = [localTagGroupsById[groupId].groupIndex]
+      ..groupNames = [localTagGroupsById[groupId].groupName]
       ..isUnifier = false
       ..text = ''
       ..shortcut = ''
       ..visible = true
       ..type = model.TagType.normal;
-    addTag(tag);
-    editedTags[tag.tagId] = tag;
+    populateTagInLocal(tag);
     return tag;
   }
 
-  /// Returns a copy of the original tag with the given [id], with the given new [text] and/or [group].
-  /// Also adds the tag to the list of tags that have been edited and need to be saved.
-  model.Tag modifyTag(String id, {String text, String group, model.TagType type}) {
-    model.Tag tag = getTagById(id);
-    model.Tag newTag = model.Tag.fromData(tag.toData())..docId = tag.tagId;
-    if (text != null) {
-      newTag.text = text;
+  List<model.Tag> populateTagsInLocal(List<model.Tag> tags) {
+    for (var tag in tags) {
+      populateTagInLocal(tag);
     }
-    if (group != null) {
-      newTag.groups = [group];
-    }
-    if (type != null) {
-      newTag.type = type;
-    }
-    updateTag(newTag);
-    editedTags[newTag.tagId] = newTag;
-    return newTag;
+
+    return tags;
   }
 
-  /// Deletes the tag with the given [id] from the managed list.
-  /// Also adds the tag to the list of tags to be deleted and need to be saved.
-  model.Tag deleteTag(String id) {
-    model.Tag tag = getTagById(id);
-    removeTag(tag);
-    editedTags.remove(tag.tagId);
-    deletedTags[tag.tagId] = tag;
+  model.Tag populateTagInLocal(model.Tag tag) {
+    localTagsById[tag.tagId] = tag;
+    for(var i = 0; i < tag.groupIds.length; ++i) {
+      localTagGroupsById[tag.groupIds[i]] = TagGroup(tag.groupIds[i], tag.groupNames[i], tag.groupIndices[i]);
+    }
+    _updateGroupDetailsInLocalTags();
     return tag;
   }
 
-  /// Creates a new tag group and returns its name.
-  /// If [groupName] is given, it will use that name, otherwise it will generate a placeholder name.
-  String createTagGroup([String groupName]) {
-    var newGroupName = groupName ?? nextTagGroupName;
-    _tagsByGroup[newGroupName] = [];
-    return newGroupName;
+  TagGroup createGroupInLocal(String name) {
+    var id = model.generateTagGroupId();
+    var group = TagGroup(id, name, _getNextGroupIndex());
+    localTagGroupsById[id] = group;
+    editedGroupIds.add(id);
+    return group;
   }
 
-  /// Renames a tag group and propagates the change to all tags in the group.
-  /// Adds the modified tags to the list of tags that have been edited and need to be saved.
-  void renameTagGroup(String groupName, String newGroupName) {
-    createTagGroup(newGroupName);
-    var tagsToModify = _tagsByGroup[groupName].toList();
-    for (var tag in tagsToModify) {
-      modifyTag(tag.tagId, group: newGroupName);
+  void renameGroupInLocal(String id, String name) {
+    if (!localTagGroupsById.containsKey(id)) {
+      log.warning("renameGroupInLocal: Unable to find group with id $id");
+      return;
     }
-    _tagsByGroup.remove(groupName);
+    _updateGroupDetailsInLocalTags();
+    localTagGroupsById[id].groupName = name;
+    editedGroupIds.add(id);
+    // todo: eb: add edited tags
   }
 
-  /// Deletes the tag group with the given [groupName] and the tags in that group from the managed list of tags.
-  /// Also adds these tags to the list of tags to be deleted and need to be saved.
-  void deleteTagGroup(String groupName) {
-    var tagsToDelete = _tagsByGroup[groupName].toList();
-    for (var tag in tagsToDelete) {
-      deleteTag(tag.tagId);
+  void removeAllTagsFromGroupInLocal(String groupId) {
+    if (!localTagGroupsById.containsKey(groupId)) {
+      log.warning("removeAllTagsFromGroupInLocal: Unable to find group with id $groupId");
+      return;
     }
-    _tagsByGroup.remove(groupName);
+
+    tagsInLocal.forEach((tag) {
+      tag.groupIds.remove(groupId);
+    });
+    _updateGroupDetailsInLocalTags();
   }
 
-  /// The tags that have been edited and need to be saved, stored as a `Map<tagId, Tag>`.
-  Map<String, model.Tag> editedTags = {};
-
-  /// The tags that have been deleted and need to be saved, stored as a `Map<tagId, Tag>`.
-  Map<String, model.Tag> deletedTags = {};
-
-  /// When a tag is moved across groups, we need to remember the origin group
-  Set<String> movedFromGroupIds = {};
-
-  /// Getters for unsaved tag Ids, group Ids derived from editedTags, deletedTags
-  Set<String> get unsavedTagIds => Set.from(List.from(editedTags.keys)..addAll(deletedTags.keys));
-  Set<String> get unsavedGroupIds {
-    var editedTagGroups = editedTags.values.map((tag) => tag.groups).expand((e) => e); //.toList();
-    var deletedTagGroups = deletedTags.values.map((tag) => tag.groups).expand((e) => e); //.toList();
-    Set<String> setString = Set.from(List.from(editedTagGroups)..addAll(deletedTagGroups))..addAll(movedFromGroupIds);
-    return setString;
+  model.Tag updateTypeInLocal(String id, model.TagType newType) {
+    localTagsById[id].type = newType;
+    editedTagIds.add(id);
+    return localTagsById[id];
   }
 
-  /// Returns whether there's any edited or deleted tags to be saved.
-  bool get hasUnsavedTags => editedTags.isNotEmpty || deletedTags.isNotEmpty || movedFromGroupIds.isNotEmpty;
+  model.Tag updateTextInLocal(String id, String newText) {
+    localTagsById[id].text = newText;
+    editedTagIds.add(id);
+    return localTagsById[id];
+  }
+
+  void reorderGroupInLocal(String id, int index) {
+    if (!localTagGroupsById.containsKey(id)) {
+      log.warning("_renameGroupInLocal: Unable to find group with id $id");
+      return;
+    }
+    var groupIds = localTagGroupsById.values.map((tagGroup) => tagGroup.groupId).toList();
+    groupIds.sort((groupIdA, groupIdB) => localTagGroupsById[groupIdA].groupIndex.compareTo(localTagGroupsById[groupIdB].groupIndex));
+    groupIds.remove(id);
+    groupIds.insert(index, id);
+    _updateGroupDetailsInLocalTags();
+  }
+
+  List<model.Tag> removeTagsInLocal(List<String> tagIds) {
+    return tagIds.map((id) => removeTagInLocal(id)).toList();
+  }
+
+  model.Tag removeTagInLocal(String tagId) {
+    deletedTagIds.add(tagId);
+    var tagToRemove = localTagsById.remove(tagId);
+    return tagToRemove;
+  }
+
+  model.Tag addTagToLocalGroup(model.Tag tag, String groupId) {
+    localTagsById[tag.tagId] = tag;
+    if (!tag.groupIds.contains(groupId)) {
+      tag.groupIds.add(groupId);
+    }
+    _updateGroupDetailsInLocalTags();
+    return tag;
+  }
+
+  model.Tag removeTagFromLocalGroup(String tagId, String groupId, {bool skipUpdate = false}) {
+    var removed = localTagsById[tagId].groupIds.remove(groupId);
+    if (!removed) {
+      log.warning("_removeTagFromLocalGroup: Unable to find tag $tagId in group $groupId");
+    }
+    if (!skipUpdate) {
+      _updateGroupDetailsInLocalTags();
+    }
+    return localTagsById[tagId];
+  }
+
+  void moveTagAcrossLocalGroup(String tagId, String fromGroupId, String toGroupId) {
+    if (fromGroupId == toGroupId) return;
+    if (!localTagsById.containsKey(tagId)) {
+      log.warning("_moveTag: Unable to find tag $tagId");
+    }
+    localTagsById[tagId].groupIds.remove(fromGroupId);
+    localTagsById[tagId].groupIds.add(toGroupId);
+    _updateGroupDetailsInLocalTags();
+  }
+
+  List<model.Tag> populateTagsInStorage(List<model.Tag> tags) {
+    for (var tag in tags) {
+      populateTagInStorage(tag);
+    }
+    return tags;
+  }
+
+  model.Tag populateTagInStorage(model.Tag tag) {
+    storageTagsById[tag.tagId] = tag;
+    for(var i = 0; i < tag.groupIds.length; ++i) {
+      storageTagGroupsById[tag.groupIds[i]] = TagGroup(tag.groupIds[i], tag.groupNames[i], tag.groupIndices[i]);
+    }
+    _updateGroupDetailsInStorageTags();
+    // todo: eb: check for diff
+    populateTagInLocal(tag);
+    return tag;
+  }
+
+  List<model.Tag> removeTagsFromStorage(List<String> tagIds) {
+    return tagIds.map((id) => removeTagFromStorage(id)).toList();
+  }
+
+  model.Tag removeTagFromStorage(String tagId) {
+    var removedTag = storageTagsById.remove(tagId);
+    return removedTag;
+  }
+
+  void _updateGroupDetailsInLocalTags() {
+    localTagsById.removeWhere((key, tag) {
+      if (tag.groupIds.isEmpty) {
+        deletedTagIds.add(tag.tagId);
+      }
+      return tag.groupIds.isEmpty;
+    });
+    localTagsById.values.forEach((tag) {
+      tag.groupNames = tag.groupIds.map((id) => localTagGroupsById[id].groupName).toList();
+      tag.groupIndices = tag.groupIds.map((id) => localTagGroupsById[id].groupIndex).toList();
+    });
+  }
+
+  void _updateGroupDetailsInStorageTags() {
+    storageTagsById.values.forEach((tag) {
+      tag.groupNames = tag.groupIds.map((id) => storageTagGroupsById[id].groupName).toList();
+      tag.groupIndices = tag.groupIds.map((id) => storageTagGroupsById[id].groupIndex).toList();
+    });
+  }
 }

--- a/webapp/lib/app/configurator/tags/controller_tag_helper.dart
+++ b/webapp/lib/app/configurator/tags/controller_tag_helper.dart
@@ -82,6 +82,7 @@ class TagManager {
     tag.groupIds
       ..remove(oldGroup)
       ..add(newGroup);
+    addEditedTag(tagId);
     _updateGroupDetailsInLocalTags();
     return tag;
   }

--- a/webapp/lib/app/configurator/tags/controller_view_helper.dart
+++ b/webapp/lib/app/configurator/tags/controller_view_helper.dart
@@ -6,7 +6,7 @@ List<MenuItem> getMenuItems(model.Tag tag) {
   var copyId = DivElement()..innerText = "Copy ID";
   return [
     MenuItem(markAsImportant, () {
-      _view.appController.command(TagsConfigAction.updateTagType, new TagData(tag.tagId, groupId: tag.groups.first, newType: tagImportant ? model.TagType.normal : model.TagType.important));
+      _view.appController.command(TagsConfigAction.updateTagType, new TagData(tag.tagId, groupId: tag.groupIds.first, newType: tagImportant ? model.TagType.normal : model.TagType.important));
     }),
     MenuItem(copyId, () {
       window.navigator.clipboard.writeText(tag.tagId);

--- a/webapp/lib/app/configurator/tags/controller_view_helper.dart
+++ b/webapp/lib/app/configurator/tags/controller_view_helper.dart
@@ -73,7 +73,7 @@ void _updateUnsavedIndicators(Map<String, List<model.Tag>> tagsByGroup, Set<Stri
 Map<String, List<model.Tag>> _groupTagsIntoCategories(List<model.Tag> tags) {
   Map<String, List<model.Tag>> result = {};
   for (model.Tag tag in tags) {
-    if (tag.groupIds.isEmpty) { 
+    if (tag.groupIds.isEmpty) {
       result.putIfAbsent("", () => []).add(tag);
       continue;
     }

--- a/webapp/lib/app/configurator/tags/view.dart
+++ b/webapp/lib/app/configurator/tags/view.dart
@@ -122,9 +122,6 @@ class TagGroupView extends AccordionItem {
     tagViewsById = {};
   }
 
-  void set name(String text) => _groupName = text;
-  String get name => _groupName;
-
   void requestToDelete() {
     expand();
     InlineOverlayModal warningModal;

--- a/webapp/lib/app/configurator/tags/view.dart
+++ b/webapp/lib/app/configurator/tags/view.dart
@@ -68,6 +68,7 @@ class TagsConfigurationPageView extends ConfigurationPageView {
 }
 
 class TagGroupView extends AccordionItem {
+  String id;
   String _groupName;
   TextEdit editableTitle;
   DivElement _header;
@@ -77,12 +78,12 @@ class TagGroupView extends AccordionItem {
 
   Map<String, ConfigureTagView> tagViewsById;
 
-  TagGroupView(id, this._groupName, this._header, this._body) : super(id, _header, _body, false) {
+  TagGroupView(this.id, this._groupName, this._header, this._body) : super(id, _header, _body, false) {
     _groupName = _groupName ?? '';
 
     editableTitle = TextEdit(_groupName, removable: true)
       ..onEdit = (value) {
-        _view.appController.command(TagsConfigAction.updateTagGroup, new TagGroupData(_groupName, newGroupName: value));
+        _view.appController.command(TagsConfigAction.updateTagGroup, new TagGroupData(id, newGroupName: value));
         _groupName = value;
       }
       ..onDelete = () {
@@ -98,7 +99,7 @@ class TagGroupView extends AccordionItem {
 
     _addButton = Button(ButtonType.add);
     _addButton.renderElement.onClick.listen((e) {
-      _view.appController.command(TagsConfigAction.addTag, new TagData(null, groupId: _groupName));
+      _view.appController.command(TagsConfigAction.addTag, new TagData(null, groupId: id));
     });
     _body.append(_addButton.renderElement);
 
@@ -114,7 +115,7 @@ class TagGroupView extends AccordionItem {
       var tagId = tag.dataset['id'];
       var groupId = tag.dataset['group-id'];
       expand();
-      _view.appController.command(TagsConfigAction.moveTag, new TagData(tagId, groupId: groupId, newGroupId: name));
+      _view.appController.command(TagsConfigAction.moveTag, new TagData(tagId, groupId: groupId, newGroupId: id));
       tag.remove();
     });
 
@@ -128,7 +129,7 @@ class TagGroupView extends AccordionItem {
     expand();
     InlineOverlayModal warningModal;
     warningModal = new InlineOverlayModal('Are you sure you want to remove this group?', [
-      new Button(ButtonType.text, buttonText: 'Yes', onClick: (_) => _view.appController.command(TagsConfigAction.removeTagGroup, new TagGroupData(name))),
+      new Button(ButtonType.text, buttonText: 'Yes', onClick: (_) => _view.appController.command(TagsConfigAction.removeTagGroup, new TagGroupData(id))),
       new Button(ButtonType.text, buttonText: 'No', onClick: (_) => warningModal.remove()),
     ]);
     renderElement.append(warningModal.inlineOverlayModal);

--- a/webapp/pubspec.lock
+++ b/webapp/pubspec.lock
@@ -263,11 +263,9 @@ packages:
   katikati_ui_lib:
     dependency: "direct main"
     description:
-      path: ui
-      ref: "71a04421db4aee3ee9c41fec91b3155a7e083887"
-      resolved-ref: "71a04421db4aee3ee9c41fec91b3155a7e083887"
-      url: "git@github.com:larksystems/katikati_common_lib.git"
-    source: git
+      path: "/Users/eb/GitRepos/Lark/katikati_common_lib/ui"
+      relative: false
+    source: path
     version: "0.0.1"
   logging:
     dependency: transitive

--- a/webapp/pubspec.lock
+++ b/webapp/pubspec.lock
@@ -263,9 +263,11 @@ packages:
   katikati_ui_lib:
     dependency: "direct main"
     description:
-      path: "/Users/eb/GitRepos/Lark/katikati_common_lib/ui"
-      relative: false
-    source: path
+      path: ui
+      ref: "217e8ef0dbf0febf692266e5640709043dfee265"
+      resolved-ref: "217e8ef0dbf0febf692266e5640709043dfee265"
+      url: "git@github.com:larksystems/katikati_common_lib.git"
+    source: git
     version: "0.0.1"
   logging:
     dependency: transitive

--- a/webapp/pubspec.lock
+++ b/webapp/pubspec.lock
@@ -264,8 +264,8 @@ packages:
     dependency: "direct main"
     description:
       path: ui
-      ref: "217e8ef0dbf0febf692266e5640709043dfee265"
-      resolved-ref: "217e8ef0dbf0febf692266e5640709043dfee265"
+      ref: e28907b5e8f419897a1b06b245fe6ef110b8eef4
+      resolved-ref: e28907b5e8f419897a1b06b245fe6ef110b8eef4
       url: "git@github.com:larksystems/katikati_common_lib.git"
     source: git
     version: "0.0.1"

--- a/webapp/pubspec.yaml
+++ b/webapp/pubspec.yaml
@@ -10,10 +10,11 @@ dependencies:
   intl: ^0.16.0
   uuid: ^2.0.0
   katikati_ui_lib:
-    git:
-      url: git@github.com:larksystems/katikati_common_lib.git
-      path: ui
-      ref: 71a04421db4aee3ee9c41fec91b3155a7e083887
+    path: /Users/eb/GitRepos/Lark/katikati_common_lib/ui
+    # git:
+    #   url: git@github.com:larksystems/katikati_common_lib.git
+    #   path: ui
+    #   ref: 71a04421db4aee3ee9c41fec91b3155a7e083887
 
 dev_dependencies:
   build_runner: ^1.7.0

--- a/webapp/pubspec.yaml
+++ b/webapp/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     git:
       url: git@github.com:larksystems/katikati_common_lib.git
       path: ui
-      ref: 217e8ef0dbf0febf692266e5640709043dfee265
+      ref: e28907b5e8f419897a1b06b245fe6ef110b8eef4
 
 dev_dependencies:
   build_runner: ^1.7.0

--- a/webapp/pubspec.yaml
+++ b/webapp/pubspec.yaml
@@ -10,11 +10,10 @@ dependencies:
   intl: ^0.16.0
   uuid: ^2.0.0
   katikati_ui_lib:
-    path: /Users/eb/GitRepos/Lark/katikati_common_lib/ui
-    # git:
-    #   url: git@github.com:larksystems/katikati_common_lib.git
-    #   path: ui
-    #   ref: 71a04421db4aee3ee9c41fec91b3155a7e083887
+    git:
+      url: git@github.com:larksystems/katikati_common_lib.git
+      path: ui
+      ref: 217e8ef0dbf0febf692266e5640709043dfee265
 
 dev_dependencies:
   build_runner: ^1.7.0


### PR DESCRIPTION
+ New tag manager to include local, storage data, simplified APIs
+ View & view helpers uses group id as the identifier instead of group name
+ Promise await store methods for more reliable save indicator

Known bugs:
+ newly created tag not updating on save, duplicates
+ group's unsaved indicator not cleared
+ _removeTagsFromView should not be called on already deleted group
+ group name can be duplicate, need to build checks
+ Storage vs local diffs are yet to be added
+ Error checks on the TagManager methods